### PR TITLE
Parallel persist

### DIFF
--- a/storey/aggregations.py
+++ b/storey/aggregations.py
@@ -124,9 +124,9 @@ class AggregateByKey(Flow):
             next_emit_time = next_emit_time + seconds_to_sleep_between_emits
 
     def run(self):
-        closables = super().run()
-        closables.append(self._cache)
-        return closables
+        closeables = super().run()
+        closeables.append(self._cache)
+        return closeables
 
 
 class QueryAggregationByKey(AggregateByKey):
@@ -197,9 +197,9 @@ class Persist(_ConcurrentByKeyJobExecution):
         await self._do_downstream(event)
 
     def run(self):
-        closables = super().run()
-        closables.append(self._cache)
-        return closables
+        closeables = super().run()
+        closeables.append(self._cache)
+        return closeables
 
 
 class AggregatedStoreElement:

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -194,12 +194,12 @@ class V3ioDriver(NeedsV3ioAccess):
         update_expression = ';'.join(expressions)
         return update_expression, condition_expression, pending_updates
 
-    def _discard_old_pending_items(self, pendings, max_window_millis):
+    def _discard_old_pending_items(self, pending, max_window_millis):
         res = {}
-        if pendings:
-            last_time = int(list(pendings.keys())[-1] / max_window_millis) * max_window_millis
+        if pending:
+            last_time = int(list(pending.keys())[-1] / max_window_millis) * max_window_millis
             min_time = last_time - max_window_millis
-            for time, value in pendings.items():
+            for time, value in pending.items():
                 if time > min_time:
                     res[time] = value
         return res

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -104,6 +104,9 @@ class V3ioDriver(NeedsV3ioAccess):
         should_raise_error = False
         update_expression, condition_expression, pending_updates = self._build_feature_store_update_expression(aggr_item, additional_data,
                                                                                                                partitioned_by_key)
+        if not update_expression:
+            return
+
         response = await self._v3io_client.kv.update(container, table_path, key, expression=update_expression,
                                                      condition=condition_expression,
                                                      raise_for_status=v3io.aio.dataplane.RaiseForStatus.never)
@@ -187,11 +190,22 @@ class V3ioDriver(NeedsV3ioAccess):
 
         return update_expression, condition_expression, pending_updates
 
+    def _discard_old_pending_items(self, pendings, max_window_millis):
+        res = {}
+        if pendings:
+            last_time = int(list(pendings.keys())[-1] / max_window_millis) * max_window_millis
+            min_time = last_time - max_window_millis
+            for time, value in pendings.items():
+                if time > min_time:
+                    res[time] = value
+        return res
+
     def _build_conditioned_feature_store_request(self, aggregation_element, pending=None):
         expressions = []
 
         times_update_expressions = {}
         pending_updates = {}
+        initialized_attributes = {}
         for name, bucket in aggregation_element.aggregation_buckets.items():
             # Only save raw aggregates, not virtual
             if bucket.should_persist:
@@ -199,7 +213,8 @@ class V3ioDriver(NeedsV3ioAccess):
                 if pending:
                     items_to_update = pending[name]
                 else:
-                    pending_updates[name] = bucket.get_and_flush_pending()
+                    # In case we have pending data that spreads over more then 2 windows discard the old ones.
+                    pending_updates[name] = self._discard_old_pending_items(bucket.get_and_flush_pending(), bucket.window.max_window_millis)
                     items_to_update = pending_updates[name]
                 for bucket_start_time, aggregation_value in items_to_update.items():
                     # the relevant attribute out of the 2 feature attributes
@@ -213,23 +228,26 @@ class V3ioDriver(NeedsV3ioAccess):
 
                     get_array_time_expr = f'if_not_exists({array_time_attribute_name},0:0)'
                     # TODO: Once IG-16915 fixed remove occurrences of `tmp_arr` and `workaround_expression`
-                    workaround_expression = f'{array_attribute_name}=tmp_arr_{array_attribute_name};delete(tmp_arr_{array_attribute_name})'
-                    init_expression = f'tmp_arr_{array_attribute_name}=if_else(({get_array_time_expr}<{expected_time_expr}),' \
-                                      f"init_array({bucket.window.total_number_of_buckets},'double'," \
-                                      f'{aggregation_value.get_default_value()}),{array_attribute_name});{workaround_expression}'
+                    if not initialized_attributes.get(array_attribute_name, 0) == expected_time:
+                        initialized_attributes[array_attribute_name] = expected_time
+                        workaround_expression = \
+                            f'{array_attribute_name}=tmp_arr_{array_attribute_name};delete(tmp_arr_{array_attribute_name})'
+                        init_expression = f'tmp_arr_{array_attribute_name}=if_else(({get_array_time_expr}<{expected_time_expr}),' \
+                            f"init_array({bucket.window.total_number_of_buckets},'double'," \
+                            f'{aggregation_value.get_default_value()}),{array_attribute_name});{workaround_expression}'
+                        expressions.append(init_expression)
 
                     arr_at_index = f'{array_attribute_name}[{index_to_update}]'
                     update_array_expression = f'{arr_at_index}=if_else(({get_array_time_expr}>{expected_time_expr}),{arr_at_index},' \
-                                              f'{self._get_update_expression_by_aggregation(arr_at_index, aggregation_value)})'
+                        f'{self._get_update_expression_by_aggregation(arr_at_index, aggregation_value)})'
 
-                    expressions.append(init_expression)
                     expressions.append(update_array_expression)
 
                     # Separating time attribute updates, so that they will be executed in the end and only once per feature name.
                     if array_time_attribute_name not in times_update_expressions:
                         times_update_expressions[array_time_attribute_name] = f'{array_time_attribute_name}=' \
-                                                                              f'if_else(({get_array_time_expr}<{expected_time_expr}),' \
-                                                                              f'{expected_time_expr},{array_time_attribute_name})'
+                            f'if_else(({get_array_time_expr}<{expected_time_expr}),' \
+                            f'{expected_time_expr},{array_time_attribute_name})'
 
         expressions.extend(times_update_expressions.values())
 
@@ -241,11 +259,13 @@ class V3ioDriver(NeedsV3ioAccess):
         times_update_expressions = {}
         new_cached_times = {}
         pending_updates = {}
+        initialized_attributes = {}
         for name, bucket in aggregation_element.aggregation_buckets.items():
             # Only save raw aggregates, not virtual
             if bucket.should_persist:
 
-                pending_updates[name] = bucket.get_and_flush_pending()
+                # In case we have pending data that spreads over more then 2 windows discard the old ones.
+                pending_updates[name] = self._discard_old_pending_items(bucket.get_and_flush_pending(), bucket.window.max_window_millis)
                 for bucket_start_time, aggregation_value in pending_updates[name].items():
                     # the relevant attribute out of the 2 feature attributes
                     feature_attr = 'a' if int(bucket_start_time / bucket.window.max_window_millis) % 2 == 0 else 'b'
@@ -260,8 +280,10 @@ class V3ioDriver(NeedsV3ioAccess):
 
                     # Possibly initiating the array
                     if cached_time < expected_time:
-                        expressions.append(f"{array_attribute_name}=init_array({bucket.window.total_number_of_buckets},'double',"
-                                           f'{aggregation_value.get_default_value()})')
+                        if not initialized_attributes.get(array_attribute_name, 0) == expected_time:
+                            initialized_attributes[array_attribute_name] = expected_time
+                            expressions.append(f"{array_attribute_name}=init_array({bucket.window.total_number_of_buckets},'double',"
+                                               f'{aggregation_value.get_default_value()})')
                         if array_time_attribute_name not in times_update_expressions:
                             times_update_expressions[array_time_attribute_name] = \
                                 f'{array_time_attribute_name}={expected_time_expr}'

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -23,10 +23,10 @@ class Flow:
         return outlet
 
     def run(self):
-        closables = []
+        closeables = []
         for outlet in self._outlets:
-            closables.extend(outlet.run())
-        return closables
+            closeables.extend(outlet.run())
+        return closeables
 
     async def run_async(self):
         raise NotImplementedError

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -13,6 +13,7 @@ class Flow:
         self._full_event = full_event
         self._termination_result_fn = termination_result_fn
         self.context = context
+        self._closeables = []
         if name:
             self.name = name
         else:
@@ -23,10 +24,9 @@ class Flow:
         return outlet
 
     def run(self):
-        closeables = []
         for outlet in self._outlets:
-            closeables.extend(outlet.run())
-        return closeables
+            self._closeables.extend(outlet.run())
+        return self._closeables
 
     async def run_async(self):
         raise NotImplementedError

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -23,8 +23,10 @@ class Flow:
         return outlet
 
     def run(self):
+        closables = []
         for outlet in self._outlets:
-            outlet.run()
+            closables.extend(outlet.run())
+        return closables
 
     async def run_async(self):
         raise NotImplementedError
@@ -373,7 +375,7 @@ class _ConcurrentJobExecution(Flow):
 
         if self._worker_awaitable.done():
             await self._worker_awaitable
-            raise FlowError("JoinWithHttp worker has already terminated")
+            raise FlowError("ConcurrentJobExecution worker has already terminated")
 
         if event is _termination_obj:
             await self._q.put(_termination_obj)
@@ -384,6 +386,104 @@ class _ConcurrentJobExecution(Flow):
             await self._q.put((event, asyncio.get_running_loop().create_task(task)))
             if self._worker_awaitable.done():
                 await self._worker_awaitable
+
+
+class _PendingEvent:
+    def __init__(self):
+        self.in_flight = []
+        self.pending = []
+
+
+class _ConcurrentByKeyJobExecution(Flow):
+    def __init__(self, max_in_flight=8, **kwargs):
+        Flow.__init__(self, **kwargs)
+        self._max_in_flight = max_in_flight
+        self._q = None
+        self._pending_by_key = {}
+
+    async def _worker(self):
+        try:
+            while True:
+                job = await self._q.get()
+                if job is _termination_obj:
+                    for key, pending_event in self._pending_by_key.items():
+                        if self._pending_by_key[key].pending and not self._pending_by_key[key].in_flight:
+                            resp = await self._process_event(pending_event.pending[0])
+                            for event in pending_event.pending:
+                                await self._handle_completed(event, resp)
+                    if self._q.empty():
+                        break
+                    else:
+                        await self._q.put(_termination_obj)
+                        continue
+
+                event = job[0]
+                completed = await job[1]
+
+                for event in self._pending_by_key[event.key].in_flight:
+                    await self._handle_completed(event, completed)
+                self._pending_by_key[event.key].in_flight = []
+
+                # If we got more pending events for the same key process them
+                if self._pending_by_key[event.key].pending:
+                    first_event = self._pending_by_key[event.key].pending[0]
+                    self._pending_by_key[event.key].in_flight = self._pending_by_key[event.key].pending
+                    self._pending_by_key[event.key].pending = []
+
+                    task = self._process_event(first_event)
+                    await self._q.put((event, asyncio.get_running_loop().create_task(task)))
+                else:
+                    del self._pending_by_key[event.key]
+        except BaseException as ex:
+            if not self._q.empty():
+                await self._q.get()
+            raise ex
+        finally:
+            await self._cleanup()
+
+    async def _do(self, event):
+        if not self._q:
+            await self._lazy_init()
+            self._q = asyncio.queues.Queue(self._max_in_flight)
+            self._worker_awaitable = asyncio.get_running_loop().create_task(self._worker())
+
+        if self._worker_awaitable.done():
+            await self._worker_awaitable
+            raise FlowError("ConcurrentByKeyJobExecution worker has already terminated")
+
+        if event is _termination_obj:
+            await self._q.put(_termination_obj)
+            await self._worker_awaitable
+            return await self._do_downstream(_termination_obj)
+        else:
+            # Initializing the key with 2 lists. One for pending requests and one for requests that an update request has been issued for.
+            if event.key not in self._pending_by_key:
+                self._pending_by_key[event.key] = _PendingEvent()
+
+            # If there is a current update in flight for the key, add the event to the pending list. Otherwise update the key.
+            if len(self._pending_by_key[event.key].in_flight) > 0:
+                self._pending_by_key[event.key].pending.append(event)
+            else:
+                self._pending_by_key[event.key].pending.append(event)
+                self._pending_by_key[event.key].in_flight = self._pending_by_key[event.key].pending
+                self._pending_by_key[event.key].pending = []
+
+                task = self._process_event(event)
+                await self._q.put((event, asyncio.get_running_loop().create_task(task)))
+                if self._worker_awaitable.done():
+                    await self._worker_awaitable
+
+    async def _process_event(self, event):
+        raise NotImplementedError()
+
+    async def _handle_completed(self, event, response):
+        raise NotImplementedError()
+
+    async def _cleanup(self):
+        pass
+
+    async def _lazy_init(self):
+        pass
 
 
 class JoinWithHttp(_ConcurrentJobExecution):
@@ -613,7 +713,7 @@ class Cache:
         store._storage = self._storage
         self._aggregation_store = store
 
-    async def _persist_key(self, key):
+    async def persist_key(self, key):
         aggr_by_key = self._aggregation_store[key]
         additional_cache_data_by_key = self._cache.get(key, None)
         await self._storage._save_key(self._container, self._table_path, key, aggr_by_key, self._partitioned_by_key,


### PR DESCRIPTION
* create `_ConcurrentByKeyJobExecution` -> base class for concurrent execution across different keys
* add notion of `closeables` that will be "closed" on flow termination. every step can subscribe his associated closeables to be closed in the end of the flow
* several aggregation saving bugs that came up because of the above changes