### PR TITLE
Lock dependency versions.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-build~=0.1.0
-flake8~=3.8.3
-flake8-bugbear~=20.1.4
-pytest~=5.4.3
-pytest-benchmark~=3.2.3
+build==0.1.0
+flake8==3.8.4
+flake8-bugbear==20.1.4
+pytest==5.4.3
+pytest-benchmark==3.2.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-build==0.1.0
-flake8==3.8.4
-flake8-bugbear==20.1.4
-pytest==5.4.3
-pytest-benchmark==3.2.3
+build~=0.1.0
+flake8~=3.8.3
+flake8-bugbear~=20.1.4
+pytest~=5.4.3
+pytest-benchmark~=3.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-aiohttp~=3.7.3
-v3io~=0.5.5
-pandas~=1.1.4
-pyarrow~=1.0.1
+aiohttp==3.7.3
+v3io==0.5.5
+pandas==1.1.5
+pyarrow==1.0.1
 grpcio-tools==1.30.0
 grpcio==1.30.0
-v3io-frames~=0.8.6
+v3io-frames==0.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.7.3
-v3io==0.5.5
+v3io~=0.5.5
 pandas==1.1.5
 pyarrow==1.0.1
 grpcio-tools==1.30.0
 grpcio==1.30.0
-v3io-frames==0.8.6
+v3io-frames~=0.8.6


### PR DESCRIPTION
We don't use a Pipfile.lock to avoid targeting a specific version of Python.