### PR TITLE
Fix PyArrow breakage.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp~=3.7
 v3io~=0.5
 pandas~=1.0
+numpy~=1.19.5
 pyarrow~=1.0
 grpcio-tools~=1.30.0
 grpcio~=1.30.0


### PR DESCRIPTION
Fixes
```
pyarrow.lib.ArrowTypeError: ('Did not pass numpy.dtype object', 'Conversion failed for column my_int with type int64')
```

See https://github.com/Azure/MachineLearningNotebooks/issues/1314