### PR TITLE
Flatten/copy bug issue fix

### DIFF
--- a/storey/dtypes.py
+++ b/storey/dtypes.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Union, Optional, Callable, List
-from copy import deepcopy
 
-from .utils import parse_duration, bucketPerWindow, get_one_unit_of_duration
 from .aggregation_utils import get_all_raw_aggregates
+from .utils import parse_duration, bucketPerWindow, get_one_unit_of_duration
 
 _termination_obj = object()
 
@@ -49,24 +48,6 @@ class Event:
 
     def __str__(self):
         return f'Event(id={self.id}, key={str(self.key)}, time={self.time}, body={self.body})'
-
-    def copy(self, body=None, key=None, time=None, id=None, headers=None, method=None, path=None, content_type=None,
-             awaitable_result=None,
-             deep_copy=False) -> 'Event':
-        if deep_copy and body is None and self.body is not None:
-            body = deepcopy(self.body)
-
-        return Event(
-            body=body or self.body,
-            key=key or self.key,
-            time=time or self.time,
-            id=id or self.id,
-            headers=headers or self.headers,
-            method=method or self.method,
-            path=path or self.path,
-            content_type=content_type or self.content_type,
-            awaitable_result=awaitable_result or self._awaitable_result
-        )
 
 
 class V3ioError(Exception):

--- a/storey/steps/flatten.py
+++ b/storey/steps/flatten.py
@@ -1,18 +1,5 @@
-from storey import Flow
-from storey.dtypes import _termination_obj
+from storey import FlatMap
 
 
-class Flatten(Flow):
-    """
-    Splits an event with an iterable body into multiple events.
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(full_event=True, **kwargs)
-
-    async def _do(self, event):
-        if event is _termination_obj:
-            return await self._do_downstream(_termination_obj)
-        else:
-            for element in event.body:
-                await self._do_downstream(event.copy(body=element))
+def Flatten(**kwargs):
+    return FlatMap(lambda x: x, **kwargs)

--- a/storey/steps/flatten.py
+++ b/storey/steps/flatten.py
@@ -2,4 +2,7 @@ from storey import FlatMap
 
 
 def Flatten(**kwargs):
+    # Please note that Flatten forces full_event=False, since otherwise we can't iterate the body of the event
+    if kwargs:
+        kwargs["full_event"] = False
     return FlatMap(lambda x: x, **kwargs)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import math
 import os
 import queue
@@ -2198,9 +2199,14 @@ def test_async_metadata_fields():
 
 
 def test_uuid():
+    def copy_and_set_body(event):
+        copy_event = copy.copy(event)
+        copy_event.body = copy_event.id
+        return copy_event
+
     controller = build_flow([
         SyncEmitSource(),
-        Map(lambda event: event.copy(body=event.id), full_event=True),
+        Map(copy_and_set_body, full_event=True),
         Reduce([], append_and_return)
     ]).run()
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -358,6 +358,20 @@ def test_flatten():
     controller.await_termination()
 
 
+def test_flatten_forces_full_event_false():
+    controller = build_flow(
+        [
+            SyncEmitSource(),
+            Flatten(full_event=True),
+            Assert().contains_all_of([1, 2, 3, 4, 5, 6])
+        ]
+    ).run()
+
+    controller.emit([1, 2, 3, 4, 5, 6])
+    controller.terminate()
+    controller.await_termination()
+
+
 def test_foreach():
     event_ids = set()
     controller = build_flow(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -64,17 +64,3 @@ def test_emit_policy_period():
     policy = _dict_to_emit_policy(policy_dict)
     assert type(policy) == EmitAfterPeriod
     assert policy.delay_in_seconds == 8
-
-
-def test_event_copy():
-    origin = Event(1, "a", id="asd")
-    copy = origin.copy({1: "a"}, "b")
-    second_copy = copy.copy(deep_copy=True)
-
-    assert id(origin.id) == id(copy.id)
-    assert copy.id == "asd"
-
-    copy.body[2] = "b"
-
-    assert len(copy.body) == 2
-    assert len(second_copy.body) == 1


### PR DESCRIPTION
An issue was spotted when a customer was using `ModelServerV2.to_mock_server()`, caused by using a custom event class (`MockEvent`) instead of Storey's `Event` class. The custom event class was not properly aligned with Storey's Event class interface and therefore failed on steps that use the Event.copy method.
  
This PR introduces a number of minor changes to address this issue. 
1) Simplified `Flatten` implementation to use `FlatMap` internally (to keep a consistent behavior between the two)
2) Removed the copy method from Event class, since it introduced too much assumptions about the what type of event will be used in the flow.
3) Updated tests to reflect changes.