### PR TITLE
ML-887: Always write outstanding streaming records when worker is idle.

### DIFF
--- a/storey/targets.py
+++ b/storey/targets.py
@@ -594,7 +594,7 @@ class StreamTarget(Flow, _Writer):
     :type storage_options: dict
     """
 
-    def __init__(self, storage: Driver, stream_path: str, sharding_func: Optional[Callable[[Event], int]] = None, batch_size: int = 1,
+    def __init__(self, storage: Driver, stream_path: str, sharding_func: Optional[Callable[[Event], int]] = None, batch_size: int = 8,
                  columns: Optional[List[str]] = None, infer_columns_from_data: Optional[bool] = None, **kwargs):
         kwargs['stream_path'] = stream_path
         kwargs['batch_size'] = batch_size

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -658,8 +658,7 @@ class StreamTarget(Flow, _Writer):
                         req = in_flight_reqs[shard_id]
                         in_flight_reqs[shard_id] = None
                         await self._handle_response(req)
-                        if len(buffers[shard_id]) >= self._batch_size:
-                            self._send_batch(buffers, in_flight_reqs, shard_id)
+                        self._send_batch(buffers, in_flight_reqs, shard_id)
                 event = await self._q.get()
                 if event is _termination_obj:  # handle outstanding batches and in flight requests on termination
                     for req in in_flight_reqs:


### PR DESCRIPTION
Set default batch_size back to 8. Add test.