### PR TITLE
Raise grpcio version upper bound.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyarrow>=1,<4
 # Upper limit is in order to avoid surprises with this sensitive dependency.
 grpcio-tools>=1.30,!=1.34.0,<1.42
 grpcio>=1.30,!=1.34.0,<1.42
-v3io-frames~=0.8
+v3io-frames~=0.10
 v3iofs~=0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ v3io~=0.5.8
 pandas~=1.0
 numpy>=1.16.5, <1.20.0
 pyarrow>=1,<4
-# Can be loosened, but grpcio 1.34.0 must not be used as it segfaults (1.34.1 ok).
-grpcio-tools>=1.30,<1.33
-grpcio>=1.30,<1.33
+# grpcio 1.34.0 must not be used as it segfaults (1.34.1 ok).
+# Upper limit is in order to avoid surprises with this sensitive dependency.
+grpcio-tools>=1.30,!=1.34.0,<1.42
+grpcio>=1.30,!=1.34.0,<1.42
 v3io-frames~=0.8
 v3iofs~=0.1


### PR DESCRIPTION
Raise v3io-frames minimum version.

Motivation is to avoid conflict with google-cloud-bigquery.