### PR TITLE
Fix field extractor for targets

### DIFF
--- a/storey/targets.py
+++ b/storey/targets.py
@@ -39,8 +39,7 @@ class _Writer:
         self._retain_dict = retain_dict
         self._storage_options = storage_options
 
-        self._field_extractor = lambda event_body, field_name: \
-            event_body.get(field_name)
+        self._field_extractor = lambda event_body, field_name: event_body.get(field_name)
         self._write_missing_fields = False
 
         def parse_notation(columns, metadata_columns, rename_columns):

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -39,7 +39,8 @@ class _Writer:
         self._retain_dict = retain_dict
         self._storage_options = storage_options
 
-        self._field_extractor = lambda event_body, field_name: event_body.get(field_name)
+        self._field_extractor = lambda event_body, field_name: \
+            event_body.get(field_name)
         self._write_missing_fields = False
 
         def parse_notation(columns, metadata_columns, rename_columns):

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -39,7 +39,7 @@ class _Writer:
         self._retain_dict = retain_dict
         self._storage_options = storage_options
 
-        self._field_extractor = lambda event_body, field_name: event_body[field_name]
+        self._field_extractor = lambda event_body, field_name: event_body.get(field_name)
         self._write_missing_fields = False
 
         def parse_notation(columns, metadata_columns, rename_columns):


### PR DESCRIPTION
Fix bug of field extractor - when trying to get non-existing key we get KeyError. Now getting None and handling as expected.
Fix bug [ML-1363](https://jira.iguazeng.com/browse/ML-1363)