### PR TITLE
ML-2286: Allow PyArrow to set parquet schema

### DIFF
--- a/integration/test_flow_integration.py
+++ b/integration/test_flow_integration.py
@@ -13,9 +13,7 @@ import v3io_frames as frames
 from storey import Filter, JoinWithV3IOTable, SendToHttp, Map, Reduce, SyncEmitSource, HttpRequest, build_flow, \
     StreamTarget, V3ioDriver, TSDBTarget, Table, JoinWithTable, MapWithState, NoSqlTarget, DataframeSource, \
     CSVSource, AsyncEmitSource
-from .integration_test_utils import V3ioHeaders, append_return, test_base_time, setup_kv_teardown_test, \
-    setup_teardown_test, \
-    assign_stream_teardown_test, create_stream
+from .integration_test_utils import V3ioHeaders, append_return, test_base_time, create_stream
 
 
 class GetShardData(V3ioHeaders):
@@ -122,7 +120,10 @@ def test_write_to_v3io_stream_timestamps(assign_stream_teardown_test):
     ]).run()
     controller.await_termination()
     shard0_data = asyncio.run(GetShardData().get_shard_data(f'{stream_path}/0'))
-    assert shard0_data == [b'{"datetime": "2012-08-08 21:46:24.862000", "string": "hello", "ts": "2018-05-07 13:52:37"}']
+    assert len(shard0_data) == 1
+    assert json.loads(shard0_data[0].decode("utf-8")) == {
+        "datetime": "2012-08-08 21:46:24.862000", "string": "hello", "ts": "2018-05-07 13:52:37"
+    }
 
 
 def test_write_to_v3io_stream_with_column_inference(assign_stream_teardown_test):

--- a/integration/test_flow_integration.py
+++ b/integration/test_flow_integration.py
@@ -13,7 +13,15 @@ import v3io_frames as frames
 from storey import Filter, JoinWithV3IOTable, SendToHttp, Map, Reduce, SyncEmitSource, HttpRequest, build_flow, \
     StreamTarget, V3ioDriver, TSDBTarget, Table, JoinWithTable, MapWithState, NoSqlTarget, DataframeSource, \
     CSVSource, AsyncEmitSource
-from .integration_test_utils import V3ioHeaders, append_return, test_base_time, create_stream
+from .integration_test_utils import V3ioHeaders, append_return, test_base_time, setup_kv_teardown_test, \
+    setup_teardown_test, \
+    assign_stream_teardown_test, create_stream
+
+_prevents_ide_from_optimizing_these_away = [
+    setup_kv_teardown_test,
+    setup_teardown_test,
+    assign_stream_teardown_test,
+]
 
 
 class GetShardData(V3ioHeaders):

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -211,7 +211,6 @@ class _Writer:
                     new_data.append(new_value)
                 else:
                     new_data[column] = new_value
-            return new_data
         elif isinstance(new_data, dict):
             for column in metadata_columns:
                 metadata_attr = metadata_columns[column]
@@ -387,7 +386,7 @@ class ParquetTarget(_Batching, _Writer):
     :param infer_columns_from_data: Whether to infer columns from the first event, when events are dictionaries.
         If True, columns will be inferred from data and used in place of explicit columns list if none was provided, or appended to the
         provided list. If columns were not provided and infer_columns_from_data=False, PyArrow will infer the schema per file written,
-        which may cause the schemas to differ between files (e.g. if a column in all null in one file but not in another).
+        which may cause the schemas to differ between files (e.g. if a column is all null in one file but not in another).
         Optional. Defaults to False.
     :param partition_cols: Columns by which to partition the data into directories. The following metadata columns are also supported:
         $key, $date (e.g. 2020-02-09), $year, $month, $day, $hour, $minute, $second. A column may be specified as a tuple, such as

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2,7 +2,6 @@ import asyncio
 import copy
 import math
 import os
-import pyarrow.parquet as pq
 import queue
 import time
 import traceback
@@ -11,6 +10,7 @@ from datetime import datetime
 from random import choice
 
 import pandas as pd
+import pyarrow.parquet as pq
 import pytest
 import pytz
 from aiohttp import InvalidURL, ClientConnectorError
@@ -1922,10 +1922,14 @@ def test_write_to_parquet_with_inference(tmpdir):
     ]).run()
 
     expected = []
+    controller.emit({'only_first_event': "first", 'my_int': -1}, key=f'first_key!')
+    expected.append([f'first_key!', "first", -1, None, None])
     for i in range(10):
         controller.emit({'my_int': i, 'my_string': f'this is {i}'}, key=f'key{i}')
-        expected.append([f'key{i}', i, f'this is {i}'])
-    expected = pd.DataFrame(expected, columns=['key', 'my_int', 'my_string'], dtype='int64')
+        expected.append([f'key{i}', None, i, f'this is {i}', None])
+    controller.emit({'only_last_event': "last", 'my_int': 1000}, key=f'last_key!')
+    expected.append([f'last_key!', None, 1000, None, "last"])
+    expected = pd.DataFrame(expected, columns=['key', 'only_first_event', 'my_int', 'my_string', 'only_last_event'], dtype='int64')
     expected.set_index(['key'], inplace=True)
     controller.terminate()
     controller.await_termination()


### PR DESCRIPTION
when columns and infer_columns_from_data are not passed.