### PR TITLE
ML-2644: Limit pandas to <1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp~=3.8
 v3io~=0.5.14
-pandas~=1.0
+pandas~=1.0, <1.5.0
 numpy>=1.16.5, <1.23
 pyarrow>=1,<7
 # grpcio 1.34.0 must not be used as it segfaults (1.34.1 ok).


### PR DESCRIPTION
[ML-2644](https://jira.iguazeng.com/browse/ML-2644)