### PR TITLE
Restrict pandas version to <1.5 again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 aiohttp~=3.8
 v3io~=0.5.14
 # exclude pandas 1.5.0 due to https://github.com/pandas-dev/pandas/issues/48767
-pandas~=1.0,!=1.5.0
+# and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
+pandas~=1.0,<1.5
 numpy>=1.16.5,<1.23
 pyarrow>=1,<7
 # grpcio 1.34.0 must not be used as it segfaults (1.34.1 ok).


### PR DESCRIPTION
Due to https://github.com/pandas-dev/pandas/issues/49203

Previously we restricted it due to this other issue: https://github.com/pandas-dev/pandas/issues/48767