### PR TITLE
ML-3039: Close Table object on MapWithState termination [1.2.x]

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -491,8 +491,8 @@ class _FunctionWithStateFlow(Flow):
             self._state = self.context.get_table(self._state)
         self._fn = fn
         self._group_by_key = group_by_key
-        if hasattr(initial_state, "close"):
-            self._closeables = [initial_state]
+        if hasattr(self._state, "close"):
+            self._closeables = [self._state]
 
     async def _call(self, event):
         element = self._get_event_or_body(event)

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -305,7 +305,13 @@ class SyncEmitSource(Flow):
                 break
 
         for closeable in self._closeables:
-            await closeable.close()
+            try:
+                maybe_coroutine = closeable.close()
+                if asyncio.iscoroutine(maybe_coroutine):
+                    await maybe_coroutine
+            except Exception as ex:
+                if self.context:
+                    self.context.logger.error(f"Error trying to close {closeable}: {ex}")
 
     def _loop_thread_main(self):
         asyncio.run(self._run_loop())
@@ -529,7 +535,13 @@ class AsyncEmitSource(Flow):
             finally:
                 if event is _termination_obj or self._ex:
                     for closeable in self._closeables:
-                        await closeable.close()
+                        try:
+                            maybe_coroutine = closeable.close()
+                            if asyncio.iscoroutine(maybe_coroutine):
+                                await maybe_coroutine
+                        except Exception as ex:
+                            if self.context:
+                                self.context.logger.error(f"Error trying to close {closeable}: {ex}")
 
     def _raise_on_error(self):
         if self._ex:


### PR DESCRIPTION
1.2.x backport of #399.