### PR TITLE
ML-3880: Fix key extraction in `DataframeSource`

### DIFF
--- a/storey/sources.py
+++ b/storey/sources.py
@@ -666,7 +666,7 @@ class DataframeSource(_IterableSource, WithUUID):
                     else:
                         line_id = self._get_uuid()
                     element = self._get_element(body, columns)
-                    keys = keys[0] if len(keys) == 1 else (None if not keys else keys)
+                    keys = None if not keys else keys
                     event = Event(element, keys, id=line_id)
                     await self._do_downstream(event)
         return await self._do_downstream(_termination_obj)

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -666,11 +666,10 @@ class DataframeSource(_IterableSource, WithUUID):
                     else:
                         line_id = self._get_uuid()
                     element = self._get_element(body, columns)
-                    keys = (
-                        keys[0]
-                        if len(keys) == 1 and not isinstance(self._key_field, list)
-                        else (None if not keys else keys)
-                    )
+                    if len(keys) == 0:
+                        keys = None
+                    elif not isinstance(self._key_field, list):
+                        keys = keys[0]
                     event = Event(element, keys, id=line_id)
                     await self._do_downstream(event)
         return await self._do_downstream(_termination_obj)

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -667,7 +667,9 @@ class DataframeSource(_IterableSource, WithUUID):
                         line_id = self._get_uuid()
                     element = self._get_element(body, columns)
                     keys = (
-                        keys[0] if len(keys) == 1 and isinstance(self._key_field, str) else (None if not keys else keys)
+                        keys[0]
+                        if len(keys) == 1 and not isinstance(self._key_field, list)
+                        else (None if not keys else keys)
                     )
                     event = Event(element, keys, id=line_id)
                     await self._do_downstream(event)

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -666,7 +666,9 @@ class DataframeSource(_IterableSource, WithUUID):
                     else:
                         line_id = self._get_uuid()
                     element = self._get_element(body, columns)
-                    keys = None if not keys else keys
+                    keys = (
+                        keys[0] if len(keys) == 1 and isinstance(self._key_field, str) else (None if not keys else keys)
+                    )
                     event = Event(element, keys, id=line_id)
                     await self._do_downstream(event)
         return await self._do_downstream(_termination_obj)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -476,7 +476,6 @@ def test_indexed_dataframe_source():
     "key_field ,key1, key2", [("my_key", "key1", "key2"), (["my_key"], ["key1"], ["key2"])]  # Test case 2
 )
 def test_dataframe_source_with_metadata(key_field, key1, key2):
-    print(key_field)
     t1 = datetime(2020, 2, 15)
     t2 = datetime(2020, 2, 16)
     df = pd.DataFrame(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -473,7 +473,7 @@ def test_indexed_dataframe_source():
 
 
 @pytest.mark.parametrize(
-    "key_field ,key1, key2", [("my_key", "key1", "key2"), (["my_key"], ["key1"], ["key2"])]  # Test case 2
+    "key_field ,key1, key2", [("my_key", "key1", "key2"), (["my_key"], ["key1"], ["key2"])]
 )
 def test_dataframe_source_with_metadata(key_field, key1, key2):
     t1 = datetime(2020, 2, 15)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -472,9 +472,7 @@ def test_indexed_dataframe_source():
     assert termination_result == expected
 
 
-@pytest.mark.parametrize(
-    "key_field ,key1, key2", [("my_key", "key1", "key2"), (["my_key"], ["key1"], ["key2"])]
-)
+@pytest.mark.parametrize("key_field ,key1, key2", [("my_key", "key1", "key2"), (["my_key"], ["key1"], ["key2"])])
 def test_dataframe_source_with_metadata(key_field, key1, key2):
     t1 = datetime(2020, 2, 15)
     t2 = datetime(2020, 2, 16)
@@ -502,10 +500,8 @@ def test_dataframe_source_with_metadata(key_field, key1, key2):
             id="id2",
         ),
     ]
-    assert len(termination_result) == len(expected)
-    for result, expected_event in zip(termination_result, expected):
-        assert result == expected_event
-        assert result.key == expected_event.key  # __eq__ method does not check key.
+    assert termination_result == expected
+    assert list(map(lambda event: event.key, termination_result)) == [key1, key2]
 
 
 async def async_dataframe_source():


### PR DESCRIPTION
Fix case where the `key_field` argument is a list of size 1.