### PR TITLE
ML-3903: `QueryByKey` - input aliasing

### DIFF
--- a/storey/aggregations.py
+++ b/storey/aggregations.py
@@ -317,6 +317,8 @@ class QueryByKey(AggregateByKey):
         Defaults to updating a dict. (Optional)
     :param aliases: Dictionary specifying aliases for enriched or aggregate columns, of the
         format `{'col_name': 'new_col_name'}`. (Optional)
+    :param input_aliases: Dictionary specifying aliases for the incoming event body data, of the
+        format `{'col_name': 'new_col_name'}`. (Optional)
     :param options: Enum flags specifying query options. (Optional)
     """
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -71,6 +71,7 @@ from storey import (
 from storey.flow import Context, ReifyMetadata, Rename, _ConcurrentJobExecution
 from tests.test_aggregate_by_key import append_return
 
+
 class ATestException(Exception):
     pass
 


### PR DESCRIPTION
Associated with [ML-3903](https://jira.iguazeng.com/browse/ML-3903), https://github.com/mlrun/mlrun/pull/3672.

Open the option to aliasing he incoming event, part of the implementation of the online merger that using the relation properties. 