### PR TITLE
ML-3895: Fix date parser

### DIFF
--- a/storey/sources.py
+++ b/storey/sources.py
@@ -793,7 +793,7 @@ class CSVSource(DataframeSource):
             self._dfs.append(df)
 
     def _datetime_from_timestamp(self, timestamp):
-        if timestamp == "" or timestamp is None:
+        if timestamp == "" or pd.isna(timestamp):
             return None
         if self._timestamp_format:
             return pandas.to_datetime(timestamp, format=self._timestamp_format).floor("u").to_pydatetime()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3491,7 +3491,7 @@ def test_csv_source_with_none_values():
         "2021-04-21 15:56:53.385444",
     ]
     assert termination_result[1].key == "b"
-    excepted_result = ["b", True, math.nan, math.nan, math.nan, math.nan]
+    excepted_result = ["b", True, math.nan, math.nan, math.nan, pd.NaT]
     assert len(termination_result[1].body) == len(excepted_result)
     for x, y in zip(termination_result[1].body, excepted_result):
         if isinstance(x, float):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3473,7 +3473,7 @@ def test_query_by_key_non_aggregate():
 def test_csv_source_with_none_values():
     controller = build_flow(
         [
-            CSVSource("tests/test-with-none-values.csv", key_field="string"),
+            CSVSource("tests/test-with-none-values.csv", key_field="string", parse_dates='date_with_none'),
             Reduce([], append_and_return, full_event=True),
         ]
     ).run()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3488,7 +3488,7 @@ def test_csv_source_with_none_values():
         False,
         1,
         2.3,
-        "2021-04-21 15:56:53.385444",
+        pd.to_datetime("2021-04-21 15:56:53.385444"),
     ]
     assert termination_result[1].key == "b"
     excepted_result = ["b", True, math.nan, math.nan, math.nan, pd.NaT]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3500,6 +3500,8 @@ def test_csv_source_with_none_values():
                 assert math.isnan(y)
             else:
                 assert x == y
+        elif isinstance(x, type(pd.NaT)):
+            assert isinstance(y, type(pd.NaT))
         else:
             assert x == y
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3473,7 +3473,7 @@ def test_query_by_key_non_aggregate():
 def test_csv_source_with_none_values():
     controller = build_flow(
         [
-            CSVSource("tests/test-with-none-values.csv", key_field="string", parse_dates='date_with_none'),
+            CSVSource("tests/test-with-none-values.csv", key_field="string", parse_dates="date_with_none"),
             Reduce([], append_and_return, full_event=True),
         ]
     ).run()


### PR DESCRIPTION
Date parser should handle `na` values in `pandas` as `None` - like `Nan`/ `Nat`(not a time).

Additionally, modify `test_csv_source_with_none_values` to attempt parsing an empty date. (The code previously mentioned the date column as a string).