### PR TITLE
ML-4879: Avoid keeping reference to events in `AggregateByKey` when cache is disabled

### DIFF
--- a/storey/table.py
+++ b/storey/table.py
@@ -190,7 +190,8 @@ class Table:
             cache_item = self._get_aggregations_attrs(key)
             await cache_item.aggregate(data, timestamp)
             self._changed_keys.add(key)
-        self._pending_events.append(event)
+        if self._flush_task:
+            self._pending_events.append(event)
 
     async def _get_features(self, key, timestamp):
         if self._flush_exception is not None:


### PR DESCRIPTION
Fixes [ML-4879](https://jira.iguazeng.com/browse/ML-4879).