### PR TITLE
Bump pyarrow version to 14.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ v3io~=0.5.14
 # and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
 pandas>=1, !=1.5.*, <3
 numpy>=1.16.5,<1.23
+# <15 is just a safeguard - no tests performed with pyarrow higher then 14
 pyarrow>=1,<15
 v3io-frames~=0.10.3
 v3iofs~=0.1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ v3io~=0.5.14
 # and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
 pandas>=1, !=1.5.*, <3
 numpy>=1.16.5,<1.23
-# <15 is just a safeguard - no tests performed with pyarrow higher then 14
+# <15 is just a safeguard - no tests performed with pyarrow higher than 14
 pyarrow>=1,<15
 v3io-frames~=0.10.3
 v3iofs~=0.1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ v3io~=0.5.14
 # and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
 pandas>=1, !=1.5.*, <3
 numpy>=1.16.5,<1.23
-# pyarrow 13 and over cause test failures
-pyarrow>=1,<13
+pyarrow>=1,<15
 v3io-frames~=0.10.3
 v3iofs~=0.1.17
 xxhash>=1


### PR DESCRIPTION
Before upgrading pyarrow to version 14.0.1, we raised the minimum supported Python version in our continuous integration (CI) from Python 3.7 to Python 3.9. This change in the CI configuration automatically upgraded the pandas library to version 2.xxx because pandas 2.0 is supported starting with Python 3.9. As a result, we had to make adjustments to our tests to accommodate the new time resolutions introduced in pandas 2.0.