### PR TITLE
Fix `date_parser` deprecation warning

### DIFF
--- a/storey/sources.py
+++ b/storey/sources.py
@@ -944,19 +944,11 @@ class CSVSource(DataframeSource):
                 path,
                 header=0,
                 parse_dates=self._dates_indices,
-                date_parser=self._datetime_from_timestamp,
+                date_format=self._timestamp_format,
                 storage_options=self._storage_options,
             )
             self._validate_fields(df, path)
             self._dfs.append(df)
-
-    def _datetime_from_timestamp(self, timestamp):
-        if timestamp == "" or pd.isna(timestamp):
-            return None
-        if self._timestamp_format:
-            return pandas.to_datetime(timestamp, format=self._timestamp_format).floor("u").to_pydatetime()
-        else:
-            return datetime.fromisoformat(timestamp)
 
     def _get_element(self, body: dict, columns: List[str]):
         if self._build_dict:


### PR DESCRIPTION
```
The argument 'date_parser' is deprecated and will be removed in a future version. Please use 'date_format' instead, or read your data in as 'object' dtype and then call 'to_datetime'.
```