### PR TITLE
Fix JSON serialization of timestamps in `KafkaTarget`

### DIFF
--- a/integration/test_kafka_integration.py
+++ b/integration/test_kafka_integration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import asyncio
+import datetime
 import json
 import os
 from time import sleep
@@ -73,7 +74,7 @@ def test_kafka_target(kafka_topic_setup_teardown):
         key = None
         if i > 0:
             key = f"key{i}"
-        event = Event({"hello": i}, key)
+        event = Event({"hello": i, "time": datetime.datetime(2023, 12, 26)}, key)
         events.append(event)
         controller.emit(event)
 
@@ -88,7 +89,7 @@ def test_kafka_target(kafka_topic_setup_teardown):
                 assert record.key is None
             else:
                 assert record.key.decode("UTF-8") == event.key
-        assert record.value.decode("UTF-8") == json.dumps(event.body)
+        assert record.value.decode("UTF-8") == json.dumps(event.body, default=str)
 
 
 async def async_test_write_to_kafka_full_event_readback(kafka_topic_setup_teardown):

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -1078,7 +1078,7 @@ class KafkaTarget(Flow, _Writer):
             record = self._event_to_writer_entry(event)
             if self._full_event:
                 record = Event.wrap_for_serialization(event, record)
-            record = json.dumps(record).encode("UTF-8")
+            record = json.dumps(record, default=str).encode("UTF-8")
             partition = None
             if self._sharding_func:
                 sharding_func_result = self._sharding_func(event)


### PR DESCRIPTION
[ML-5352](https://jira.iguazeng.com/browse/ML-5352)

Consistent with the implementation of `StreamTarget`.