### PR TITLE
Bump Jinja2 docs requirements for security fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx~=5.3
 sphinx_rtd_theme~=1.2
 sphinx-copybutton~=0.3
 sphinx-togglebutton~=0.2.2
-Jinja2<3.1
+Jinja2~=3.1
 myst-nb~=0.10
 sphinx-book-theme~=1.0.1
 markdown-it-py~=2.2


### PR DESCRIPTION
https://github.com/mlrun/storey/security/dependabot/12

Dependency was introduced in #434 to fix the docs build.