### PR TITLE
Limit pandas to <2.2.0 because it requires sqlalchemy 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ aiohttp~=3.8
 v3io~=0.5.14
 # exclude pandas 1.5.0 due to https://github.com/pandas-dev/pandas/issues/48767
 # and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
-pandas>=1, !=1.5.*, <3
+# pandas 2.2 requires sqlalchemy 2
+pandas>=1, !=1.5.*, <2.2
 # upper limit is just a safeguard - tested with numpy 1.26.2
 numpy>=1.16.5,<1.27
 # <15 is just a safeguard - no tests performed with pyarrow higher than 14


### PR DESCRIPTION
Fixes this error
```
>       cur = self.con.cursor()
E       AttributeError: 'Connection' object has no attribute 'cursor'
```
which is caused by pandas refusing to import sqlalchemy because it's below 2.0.0.

https://github.com/pandas-dev/pandas/commit/b57080bf216582454e379a4e702fd7246dfbb8c4#diff-ccd2950d6f16d881f395b22ef38c981ed269b2b1609dd26a9d6e9daf0f78e104R55