### PR TITLE
[Driver] Fix V3IO driver handling of single quote in strings where double quote is not present

### DIFF
--- a/integration/test_flow_integration.py
+++ b/integration/test_flow_integration.py
@@ -1120,9 +1120,9 @@ def test_writing_quote_in_value(setup_teardown_test):
         ]
     ).run()
     controller.await_termination()
-    assert get_key_all_attrs_test_helper(setup_teardown_test, "0", keys) == {'color': "gre'en", 'num': 0}
-    assert get_key_all_attrs_test_helper(setup_teardown_test, "1", keys) == {'color': 'bl"ue', 'num': 1}
-    assert get_key_all_attrs_test_helper(setup_teardown_test, "2", keys) == {'color': 'red', 'num': 2}
+    assert get_key_all_attrs_test_helper(setup_teardown_test, "0", keys) == {"color": "gre'en", "num": 0}
+    assert get_key_all_attrs_test_helper(setup_teardown_test, "1", keys) == {"color": 'bl"ue', "num": 1}
+    assert get_key_all_attrs_test_helper(setup_teardown_test, "2", keys) == {"color": "red", "num": 2}
 
 
 def test_writing_timedelta_key(setup_teardown_test):

--- a/integration/test_flow_integration.py
+++ b/integration/test_flow_integration.py
@@ -1107,6 +1107,24 @@ def test_writing_int_key(setup_teardown_test):
     controller.await_termination()
 
 
+def test_writing_quote_in_value(setup_teardown_test):
+    keys = ["num"]
+    table = _get_table(setup_teardown_test, {"num": int, "color": str}, keys)
+
+    df = pd.DataFrame({"num": [0, 1, 2], "color": ["gre'en", 'bl"ue', "red"]})
+
+    controller = build_flow(
+        [
+            DataframeSource(df, key_field="num"),
+            NoSqlTarget(table),
+        ]
+    ).run()
+    controller.await_termination()
+    assert get_key_all_attrs_test_helper(setup_teardown_test, "0", keys) == {'color': "gre'en", 'num': 0}
+    assert get_key_all_attrs_test_helper(setup_teardown_test, "1", keys) == {'color': 'bl"ue', 'num': 1}
+    assert get_key_all_attrs_test_helper(setup_teardown_test, "2", keys) == {'color': 'red', 'num': 2}
+
+
 def test_writing_timedelta_key(setup_teardown_test):
     if setup_teardown_test.driver_name == "SQLDriver":
         pytest.skip("test_writing_timedelta_key not testing over SQLDriver because SQLITE not support interval type")

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -552,7 +552,7 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
             # in order to handle ' in value.
             # may impact performance
             if "'" in value:
-                return f"\"{value}\""
+                return f'"{value}"'
             return f"'{value}'"
         if isinstance(value, bool) or isinstance(value, float) or isinstance(value, int):
             return str(value)

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -549,8 +549,8 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
     @staticmethod
     def _convert_python_obj_to_expression_value(value):
         if isinstance(value, str):
-            # in order to handle ' in value.
-            # may impact performance
+            # in order to handle ' or " in a value.
+            # using both double (") and single (') quotation marks in the same value is not supported.
             if "'" in value:
                 return f'"{value}"'
             return f"'{value}'"

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -549,6 +549,10 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
     @staticmethod
     def _convert_python_obj_to_expression_value(value):
         if isinstance(value, str):
+            # in order to handle ' in value.
+            # may impact performance
+            if "'" in value:
+                return f"\"{value}\""
             return f"'{value}'"
         if isinstance(value, bool) or isinstance(value, float) or isinstance(value, int):
             return str(value)


### PR DESCRIPTION
If both are present, the UpdateItem operation will still fail with an expression syntax error.

[ML-5576](https://jira.iguazeng.com/browse/ML-5576)