### PR TITLE
Fix `AsyncEmitSource`

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -197,7 +197,6 @@ async def async_offset_commit():
     # Make sure that offsets are committed even before termination
     await asyncio.sleep(2)
     offsets = copy.copy(platform.offsets)
-    print(f"offsets={offsets}")
 
     try:
         assert offsets == {("/", i): num_records_per_shard for i in range(num_shards)}

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import pytest
+
+from storey.queue import SimpleAsyncQueue
+
+
+async def async_test_simple_async_queue():
+    q = SimpleAsyncQueue(2)
+
+    with pytest.raises(TimeoutError):
+        await q.get(0)
+
+    get_task = asyncio.create_task(q.get(1))
+    await q.put("x")
+    assert await get_task == "x"
+
+    await q.put("x")
+    await q.put("y")
+    put_task = asyncio.create_task(q.put("z"))
+    assert await q.get() == "x"
+    await put_task
+    assert await q.get() == "y"
+    assert await q.get() == "z"
+
+
+def test_simple_async_queue():
+    asyncio.run(async_test_simple_async_queue())


### PR DESCRIPTION
By replacing the queue timeout implementation.

[ML-4421](https://jira.iguazeng.com/browse/ML-4421)