### PR TITLE
[requirements] bump v3io-py to 0.6.2 (#504)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp~=3.8
-v3io~=0.5.14
+v3io~=0.6.2
 # exclude pandas 1.5.0 due to https://github.com/pandas-dev/pandas/issues/48767
 # and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
 # pandas 2.2 requires sqlalchemy 2


### PR DESCRIPTION
bump v3io to 0.6.2.