### PR TITLE
[TDEngine] Remove REST support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,4 +12,4 @@ redis~=4.3
 sqlalchemy~=1.4
 s3fs~=2023.9.2
 adlfs~=2023.9.0
-taospy[ws]>=2,<3
+taos-ws-py~=0.3.2

--- a/integration/test_tdengine.py
+++ b/integration/test_tdengine.py
@@ -9,7 +9,6 @@ from storey.targets import TDEngineTarget
 
 url = os.getenv("TDENGINE_URL")
 
-
 @pytest.fixture()
 def tdengine():
     db_name = "storey"
@@ -48,7 +47,7 @@ def tdengine():
 
 
 @pytest.mark.parametrize("table_col", [None, "$key", "table"])
-@pytest.mark.skipif(not url and not url.startswith("taosws"), reason="Missing TDEngine URL")
+@pytest.mark.skipif(url is None or not url.startswith("taosws"), reason="Missing Valid TDEngine URL")
 def test_tdengine_target(tdengine, table_col):
     connection, url, db_name, supertable_name, db_prefix = tdengine
     time_format = "%d/%m/%y %H:%M:%S UTC%z"

--- a/integration/test_tdengine.py
+++ b/integration/test_tdengine.py
@@ -9,6 +9,9 @@ from storey import SyncEmitSource, build_flow
 from storey.targets import TDEngineTarget
 
 url = os.getenv("TDENGINE_URL")
+user = os.getenv("TDENGINE_USER")
+password = os.getenv("TDENGINE_PASSWORD")
+has_tdengine_credentials = all([url, user, password]) or (url and url.startswith("taosws"))
 
 
 @pytest.fixture()
@@ -16,8 +19,15 @@ def tdengine():
     db_name = "storey"
     supertable_name = "test_supertable"
 
-    connection = taosws.connect(url)
-    db_prefix = ""
+    if url.startswith("taosws"):
+        connection = taosws.connect(url)
+    else:
+
+        connection = taosws.connect(
+            url=url,
+            user=user,
+            password=password,
+        )
 
     try:
         connection.execute(f"DROP DATABASE {db_name};")
@@ -26,22 +36,18 @@ def tdengine():
             raise err
 
     connection.execute(f"CREATE DATABASE {db_name};")
-
-    if not db_prefix:
-        connection.execute(f"USE {db_name}")
+    connection.execute(f"USE {db_name}")
 
     try:
-        connection.execute(f"DROP STABLE {db_prefix}{supertable_name};")
+        connection.execute(f"DROP STABLE {supertable_name};")
     except taosws.QueryError as err:  # websocket connection raises QueryError
         if "STable not exist" not in str(err):
             raise err
 
-    connection.execute(
-        f"CREATE STABLE {db_prefix}{supertable_name} (time TIMESTAMP, my_string NCHAR(10)) TAGS (my_int INT);"
-    )
+    connection.execute(f"CREATE STABLE {supertable_name} (time TIMESTAMP, my_string NCHAR(10)) TAGS (my_int INT);")
 
     # Test runs
-    yield connection, url, db_name, supertable_name, db_prefix
+    yield connection, url, user, password, db_name, supertable_name
 
     # Teardown
     connection.execute(f"DROP DATABASE {db_name};")
@@ -49,16 +55,16 @@ def tdengine():
 
 
 @pytest.mark.parametrize("table_col", [None, "$key", "table"])
-@pytest.mark.skipif(url is None or not url.startswith("taosws"), reason="Missing Valid TDEngine URL")
+@pytest.mark.skipif(not has_tdengine_credentials, reason="Missing TDEngine URL, user, and/or password")
 def test_tdengine_target(tdengine, table_col):
-    connection, url, db_name, supertable_name, db_prefix = tdengine
+    connection, url, user, password, db_name, supertable_name = tdengine
     time_format = "%d/%m/%y %H:%M:%S UTC%z"
 
     table_name = "test_table"
 
     # Table is created automatically only when using a supertable
     if not table_col:
-        connection.execute(f"CREATE TABLE {db_prefix}{table_name} (time TIMESTAMP, my_string NCHAR(10), my_int INT);")
+        connection.execute(f"CREATE TABLE {table_name} (time TIMESTAMP, my_string NCHAR(10), my_int INT);")
 
     controller = build_flow(
         [
@@ -67,6 +73,8 @@ def test_tdengine_target(tdengine, table_col):
                 url=url,
                 time_col="time",
                 columns=["my_string"] if table_col else ["my_string", "my_int"],
+                user=user,
+                password=password,
                 database=db_name,
                 table=None if table_col else table_name,
                 table_col=table_col,
@@ -99,23 +107,17 @@ def test_tdengine_target(tdengine, table_col):
     else:
         query_table = table_name
         where_clause = ""
-    result = connection.query(f"SELECT * FROM {db_prefix}{query_table} {where_clause} ORDER BY my_int;")
+    result = connection.query(f"SELECT * FROM {query_table} {where_clause} ORDER BY my_int;")
     result_list = []
     for row in result:
         row = list(row)
         for field_index, field in enumerate(result.fields):
-            typ = field.type() if url.startswith("taosws") else field["type"]
+            typ = field.type()
             if typ == "TIMESTAMP":
-                if url.startswith("taosws"):
-                    t = datetime.fromisoformat(row[field_index])
-                    # websocket returns a timestamp with the local time zone
-                    t = t.astimezone(pytz.UTC).replace(tzinfo=None)
-                    row[field_index] = t
-                else:
-                    t = row[field_index]
-                    # REST API returns a naive timestamp matching the local time zone
-                    t = t.astimezone(pytz.UTC).replace(tzinfo=None)
-                    row[field_index] = t
+                t = datetime.fromisoformat(row[field_index])
+                # websocket returns a timestamp with the local time zone
+                t = t.astimezone(pytz.UTC).replace(tzinfo=None)
+                row[field_index] = t
         result_list.append(row)
     if table_col:
         expected_result = [

--- a/integration/test_tdengine.py
+++ b/integration/test_tdengine.py
@@ -9,6 +9,7 @@ from storey.targets import TDEngineTarget
 
 url = os.getenv("TDENGINE_URL")
 
+
 @pytest.fixture()
 def tdengine():
     db_name = "storey"

--- a/integration/test_tdengine.py
+++ b/integration/test_tdengine.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import pytest
 import pytz
 import taosws
+
 from storey import SyncEmitSource, build_flow
 from storey.targets import TDEngineTarget
 
@@ -48,7 +49,9 @@ def tdengine():
 
 
 @pytest.mark.parametrize("table_col", [None, "$key", "table"])
-@pytest.mark.skipif(url is None or not url.startswith("taosws"), reason="Missing Valid TDEngine URL")
+@pytest.mark.skipif(
+    url is None or not url.startswith("taosws"), reason="Missing Valid TDEngine URL"
+)
 def test_tdengine_target(tdengine, table_col):
     connection, url, db_name, supertable_name, db_prefix = tdengine
     time_format = "%d/%m/%y %H:%M:%S UTC%z"
@@ -57,7 +60,9 @@ def test_tdengine_target(tdengine, table_col):
 
     # Table is created automatically only when using a supertable
     if not table_col:
-        connection.execute(f"CREATE TABLE {db_prefix}{table_name} (time TIMESTAMP, my_string NCHAR(10), my_int INT);")
+        connection.execute(
+            f"CREATE TABLE {db_prefix}{table_name} (time TIMESTAMP, my_string NCHAR(10), my_int INT);"
+        )
 
     controller = build_flow(
         [
@@ -98,7 +103,9 @@ def test_tdengine_target(tdengine, table_col):
     else:
         query_table = table_name
         where_clause = ""
-    result = connection.query(f"SELECT * FROM {db_prefix}{query_table} {where_clause} ORDER BY my_int;")
+    result = connection.query(
+        f"SELECT * FROM {db_prefix}{query_table} {where_clause} ORDER BY my_int;"
+    )
     result_list = []
     for row in result:
         row = list(row)

--- a/integration/test_tdengine.py
+++ b/integration/test_tdengine.py
@@ -49,9 +49,7 @@ def tdengine():
 
 
 @pytest.mark.parametrize("table_col", [None, "$key", "table"])
-@pytest.mark.skipif(
-    url is None or not url.startswith("taosws"), reason="Missing Valid TDEngine URL"
-)
+@pytest.mark.skipif(url is None or not url.startswith("taosws"), reason="Missing Valid TDEngine URL")
 def test_tdengine_target(tdengine, table_col):
     connection, url, db_name, supertable_name, db_prefix = tdengine
     time_format = "%d/%m/%y %H:%M:%S UTC%z"
@@ -60,9 +58,7 @@ def test_tdengine_target(tdengine, table_col):
 
     # Table is created automatically only when using a supertable
     if not table_col:
-        connection.execute(
-            f"CREATE TABLE {db_prefix}{table_name} (time TIMESTAMP, my_string NCHAR(10), my_int INT);"
-        )
+        connection.execute(f"CREATE TABLE {db_prefix}{table_name} (time TIMESTAMP, my_string NCHAR(10), my_int INT);")
 
     controller = build_flow(
         [
@@ -103,9 +99,7 @@ def test_tdengine_target(tdengine, table_col):
     else:
         query_table = table_name
         where_clause = ""
-    result = connection.query(
-        f"SELECT * FROM {db_prefix}{query_table} {where_clause} ORDER BY my_int;"
-    )
+    result = connection.query(f"SELECT * FROM {db_prefix}{query_table} {where_clause} ORDER BY my_int;")
     result_list = []
     for row in result:
         row = list(row)

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -870,7 +870,6 @@ class TDEngineTarget(_Batching, _Writer):
         self._url = url
         self._database = database
 
-
     def _init(self):
         import taosws
 

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -777,7 +777,8 @@ class TSDBTarget(_Batching, _Writer):
 class TDEngineTarget(_Batching, _Writer):
     """Writes incoming events to a TDEngine table.
 
-    :param url: TDEngine Websocket URL, e.g. taosws://<username>:<password>@<host>:<port>.
+    :param url: TDEngine Websocket URL. You an either provide a full URL (e.g. taosws://user:password@host:port) or
+                just the host and port (e.g. host:port) and provide the user and password separately.
     :param time_col: Name of the time column.
     :param columns: List of column names to be passed to the DataFrame constructor. Use = notation for renaming fields
         (e.g. write_this=event_field). Use $ notation to refer to metadata ($key, event_time=$time).


### PR DESCRIPTION
Install `taospy[ws]` that includes python connector to TDEngine using either REST API or WebSocket also includes installation of unnecessary dependencies such as  `pytest-cov`.
Therefore, at the moment we are going to support only the WebSocket connection that can be implemented using `taos-ws-py` which doesn't include the unnecessary dependencies.