### PR TITLE
Improve documentation of `ConcurrentExecution`'s `backoff_factor` parameter

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -947,7 +947,8 @@ class ConcurrentExecution(_ConcurrentJobExecution):
 
     :param max_in_flight: Maximum number of events to be processed at a time (default 8)
     :param retries: Maximum number of retries per event (default 0)
-    :param backoff_factor: Wait time in seconds between retries (default 1)
+    :param backoff_factor: Wait time in seconds before the first retry (default 1). Subsequent retries will each wait
+      twice as the previous retry, up to a maximum of two minutes.
     :param pass_context: If False, the process_event function will be called with just one parameter (event). If True,
       the process_event function will be called with two parameters (event, context). Defaults to False.
     :param full_event: Whether event processor should receive and return Event objects (when True),


### PR DESCRIPTION
[ML-6922](https://iguazio.atlassian.net/browse/ML-6922)

[ML-6922]: https://iguazio.atlassian.net/browse/ML-6922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ