### PR TITLE
Fix V3IO driver following change in v3io-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp~=3.8
-v3io~=0.6.4
+v3io~=0.6.9
 # exclude pandas 1.5.0 due to https://github.com/pandas-dev/pandas/issues/48767
 # and 1.5.* due to https://github.com/pandas-dev/pandas/issues/49203
 # pandas 2.2 requires sqlalchemy 2

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -532,7 +532,7 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
 
         if use_parallel:
             for attr_name, d in pexpressions.items():
-                encoded_array = kv_array.encode_list(d["values"][d["first_index"] : d["last_index"] + 1]).decode()
+                encoded_array = kv_array.encode_list(d["values"][d["first_index"] : d["last_index"] + 1])
                 paggregate = self.parallel_aggregates[d["aggregation"]]
                 sliced_array = f'{attr_name}[{d["first_index"]}..{d["last_index"]}]'
                 expressions.append(f"{sliced_array}={paggregate}({sliced_array}, blob('{encoded_array}'))")


### PR DESCRIPTION
[ML-7715](https://iguazio.atlassian.net/browse/ML-7715)

[This change](https://github.com/v3io/v3io-py/pull/126/files#diff-c6f2958ca59ceba44b4c4426fdf625aa344032067191d75ecacc5d956820cf3fR42) to a utility method in v3io-py changed its return type from bytes to string.

[ML-7715]: https://iguazio.atlassian.net/browse/ML-7715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ