### PR TITLE
Add dedicated process mode to `ParallelExecutionRunnable`

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -17,6 +17,7 @@ import copy
 import datetime
 import inspect
 import multiprocessing
+import os
 import pickle
 import time
 import traceback
@@ -1448,15 +1449,17 @@ class _ParallelExecutionRunnableResult:
         self.runtime = runtime
 
 
-parallel_execution_mechanisms = ("multiprocessing", "threading", "asyncio", "naive")
+parallel_execution_mechanisms = ("process_pool", "dedicated_process", "thread_pool", "asyncio", "naive")
 
 
 class ParallelExecutionRunnable:
     """
     Runnable to be run by a ParallelExecution step. Subclasses must assign execution_mechanism with one of:
-    * "multiprocessing" – To run in a separate process. This is appropriate for CPU or GPU intensive tasks as they
-        would otherwise block the main process by holding Python's Global Interpreter Lock (GIL).
-    * "threading" – To run in a separate thread. This is appropriate for blocking I/O tasks, as they would otherwise
+    * "process_pool" – To run in a separate process from a process pool. This is appropriate for CPU or GPU intensive
+        tasks as they would otherwise block the main process by holding Python's Global Interpreter Lock (GIL).
+    * "dedicated_process" – To run in a separate dedicated process. This is appropriate for CPU or GPU intensive tasks
+        that also require significant Runnable-specific initialization (e.g. a large model).
+    * "thread_pool" – To run in a separate thread. This is appropriate for blocking I/O tasks, as they would otherwise
         block the main event loop thread.
     * "asyncio" – To run in an asyncio task. This is appropriate for I/O tasks that use asyncio, allowing the event
         loop to continue running while waiting for a response.
@@ -1479,7 +1482,7 @@ class ParallelExecutionRunnable:
         if self.execution_mechanism not in parallel_execution_mechanisms:
             raise ValueError(
                 "ParallelExecutionRunnable's execution_mechanism attribute must be overridden with one of: "
-                '"multiprocessing", "threading", "asyncio", "naive"'
+                '"process_pool", "dedicated_process", "thread_pool", "asyncio", "naive"'
             )
         self.name = name
 
@@ -1538,12 +1541,15 @@ class ParallelExecution(Flow):
     Runs multiple jobs in parallel for each event.
 
     :param runnables: A list of ParallelExecutionRunnable instances.
+    :param max_processes: Maximum number of processes to spawn, not including dedicated ones. Defaults to the number of
+      available CPUs, or 16 if number of CPUs can't be determined.
     :param max_threads: Maximum number of threads to start. Defaults to 32.
     """
 
     def __init__(
         self,
         runnables: list[ParallelExecutionRunnable],
+        max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,
         **kwargs,
     ):
@@ -1555,6 +1561,7 @@ class ParallelExecution(Flow):
         self.runnables = runnables
         self._runnable_by_name = {}
 
+        self.max_processes = max_processes or os.cpu_count() or 16
         self.max_threads = max_threads or 32
 
         self._process_executor_by_runnable_name = {}
@@ -1570,6 +1577,7 @@ class ParallelExecution(Flow):
 
     def _init(self):
         super()._init()
+        num_processes = 0
         num_threads = 0
         mp_context = multiprocessing.get_context("spawn")
         for runnable in self.runnables:
@@ -1577,14 +1585,16 @@ class ParallelExecution(Flow):
                 raise ValueError(f"ParallelExecutionRunnable name '{runnable.name}' is not unique")
             runnable.init()
             self._runnable_by_name[runnable.name] = runnable
-            if runnable.execution_mechanism == "multiprocessing":
+            if runnable.execution_mechanism == "process_pool":
+                num_processes += 1
+            elif runnable.execution_mechanism == "dedicated_process":
                 self._process_executor_by_runnable_name[runnable.name] = ProcessPoolExecutor(
                     max_workers=1,
                     mp_context=mp_context,
                     initializer=_set_global,
                     initargs=(runnable,),
                 )
-            elif runnable.execution_mechanism == "threading":
+            elif runnable.execution_mechanism == "thread_pool":
                 num_threads += 1
             elif runnable.execution_mechanism not in ("asyncio", "naive"):
                 raise ValueError(f"Unsupported execution mechanism: {runnable.execution_mechanism}")
@@ -1593,8 +1603,10 @@ class ParallelExecution(Flow):
         num_threads = min(num_threads, self.max_threads)
 
         self._executors = {}
+        if num_processes:
+            self._executors["process_pool"] = ProcessPoolExecutor(max_workers=num_processes, mp_context=mp_context)
         if num_threads:
-            self._executors["threading"] = ThreadPoolExecutor(max_workers=num_threads)
+            self._executors["thread_pool"] = ThreadPoolExecutor(max_workers=num_threads)
 
     async def _do(self, event):
         if event is _termination_obj:
@@ -1617,19 +1629,19 @@ class ParallelExecution(Flow):
                 elif runnable.execution_mechanism == "naive":
                     future = asyncio.get_running_loop().create_future()
                     future.set_result(runnable._run(input, event.path))
-                elif runnable.execution_mechanism == "threading":
-                    executor = self._executors["threading"]
-                    future = asyncio.get_running_loop().run_in_executor(
-                        executor,
-                        runnable._run,
-                        input,
-                        event.path,
-                    )
-                else:
+                elif runnable.execution_mechanism == "dedicated_process":
                     executor = self._process_executor_by_runnable_name[runnable.name]
                     future = asyncio.get_running_loop().run_in_executor(
                         executor,
                         _static_run,
+                        input,
+                        event.path,
+                    )
+                else:
+                    executor = self._executors[runnable.execution_mechanism]
+                    future = asyncio.get_running_loop().run_in_executor(
+                        executor,
+                        runnable._run,
                         input,
                         event.path,
                     )

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -17,7 +17,6 @@ import copy
 import datetime
 import inspect
 import multiprocessing
-import os
 import pickle
 import time
 import traceback
@@ -1521,20 +1520,30 @@ class ParallelExecutionRunnable:
         return _ParallelExecutionRunnableResult(self.name, body, end - start)
 
 
+_sval = None
+
+
+def _set_global(sval):
+    global _sval
+    _sval = sval
+
+
+def _static_run(*args, **kwargs):
+    global _sval
+    return _sval._run(*args, **kwargs)
+
+
 class ParallelExecution(Flow):
     """
     Runs multiple jobs in parallel for each event.
 
     :param runnables: A list of ParallelExecutionRunnable instances.
-    :param max_processes: Maximum number of processes to spawn. Defaults to the number of available CPUs, or 16 if
-      number of CPUs can't be determined.
     :param max_threads: Maximum number of threads to start. Defaults to 32.
     """
 
     def __init__(
         self,
         runnables: list[ParallelExecutionRunnable],
-        max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,
         **kwargs,
     ):
@@ -1546,8 +1555,9 @@ class ParallelExecution(Flow):
         self.runnables = runnables
         self._runnable_by_name = {}
 
-        self.max_processes = max_processes or os.cpu_count() or 16
         self.max_threads = max_threads or 32
+
+        self._process_executor_by_runnable_name = {}
 
     def select_runnables(self, event) -> Optional[Union[list[str], list[ParallelExecutionRunnable]]]:
         """
@@ -1560,28 +1570,29 @@ class ParallelExecution(Flow):
 
     def _init(self):
         super()._init()
-        num_processes = 0
         num_threads = 0
+        mp_context = multiprocessing.get_context("spawn")
         for runnable in self.runnables:
             if runnable.name in self._runnable_by_name:
                 raise ValueError(f"ParallelExecutionRunnable name '{runnable.name}' is not unique")
-            self._runnable_by_name[runnable.name] = runnable
             runnable.init()
+            self._runnable_by_name[runnable.name] = runnable
             if runnable.execution_mechanism == "multiprocessing":
-                num_processes += 1
+                self._process_executor_by_runnable_name[runnable.name] = ProcessPoolExecutor(
+                    max_workers=1,
+                    mp_context=mp_context,
+                    initializer=_set_global,
+                    initargs=(runnable,),
+                )
             elif runnable.execution_mechanism == "threading":
                 num_threads += 1
             elif runnable.execution_mechanism not in ("asyncio", "naive"):
                 raise ValueError(f"Unsupported execution mechanism: {runnable.execution_mechanism}")
 
         # enforce max
-        num_processes = min(num_processes, self.max_processes)
         num_threads = min(num_threads, self.max_threads)
 
         self._executors = {}
-        if num_processes:
-            mp_context = multiprocessing.get_context("spawn")
-            self._executors["multiprocessing"] = ProcessPoolExecutor(max_workers=num_processes, mp_context=mp_context)
         if num_threads:
             self._executors["threading"] = ThreadPoolExecutor(max_workers=num_threads)
 
@@ -1606,11 +1617,19 @@ class ParallelExecution(Flow):
                 elif runnable.execution_mechanism == "naive":
                     future = asyncio.get_running_loop().create_future()
                     future.set_result(runnable._run(input, event.path))
-                else:
-                    executor = self._executors[runnable.execution_mechanism]
+                elif runnable.execution_mechanism == "threading":
+                    executor = self._executors["threading"]
                     future = asyncio.get_running_loop().run_in_executor(
                         executor,
                         runnable._run,
+                        input,
+                        event.path,
+                    )
+                else:
+                    executor = self._process_executor_by_runnable_name[runnable.name]
+                    future = asyncio.get_running_loop().run_in_executor(
+                        executor,
+                        _static_run,
                         input,
                         event.path,
                     )

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4782,7 +4782,7 @@ def test_filters_type():
 
 
 class RunnableBusyWait(ParallelExecutionRunnable):
-    execution_mechanism = "multiprocessing"
+    execution_mechanism = "process_pool"
     _result = 0
 
     def init(self):
@@ -4796,7 +4796,7 @@ class RunnableBusyWait(ParallelExecutionRunnable):
 
 
 class RunnableSleep(ParallelExecutionRunnable):
-    execution_mechanism = "threading"
+    execution_mechanism = "thread_pool"
     _result = 0
 
     def init(self):
@@ -4870,10 +4870,14 @@ def test_select_runnable_uniqueness():
 
 
 def test_parallel_execution():
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
+    busy_wait_dedicated.execution_mechanism = "dedicated_process"
+
     runnables = [
         RunnableWithError("error"),
-        RunnableBusyWait("busy1"),
-        RunnableBusyWait("busy2"),
+        busy_wait_pool,
+        busy_wait_dedicated,
         RunnableSleep("sleep1"),
         RunnableSleep("sleep2"),
         RunnableAsyncSleep("asleep1"),
@@ -4915,13 +4919,13 @@ def test_invalid_runnable():
     with pytest.raises(
         ValueError,
         match="ParallelExecutionRunnable's execution_mechanism attribute must be overridden with one of: "
-        '"multiprocessing", "threading", "asyncio", "naive"',
+        '"process_pool", "dedicated_process", "thread_pool", "asyncio", "naive"',
     ):
         ParallelExecutionRunnable("my_runnable")
 
 
 class RunnableMultiprocessingWithLargeData(ParallelExecutionRunnable):
-    execution_mechanism = "multiprocessing"
+    execution_mechanism = "dedicated_process"
 
     def __init__(self, data_size, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4927,16 +4927,18 @@ def test_invalid_runnable():
 class RunnableMultiprocessingWithLargeData(ParallelExecutionRunnable):
     execution_mechanism = "dedicated_process"
 
-    def __init__(self, data_size, *args, **kwargs):
+    def __init__(self, data_size: int, gpu_number: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.data = None
         self.data_size = data_size
+        self.gpu_number = gpu_number
 
     def init(self):
         self.data = list(range(self.data_size))
 
     def run(self, data, path):
         data["data_size"] = len(self.data)
+        data["gpu"] = self.gpu_number
         return data
 
 
@@ -4945,7 +4947,10 @@ def test_parallel_execution_with_large_data():
     num_records = 100
     num_runnables = 3
 
-    runnables = [RunnableMultiprocessingWithLargeData(data_size, name=f"runnable_{i}") for i in range(num_runnables)]
+    runnables = [
+        RunnableMultiprocessingWithLargeData(data_size, gpu_number=i, name=f"runnable_{i}")
+        for i in range(num_runnables)
+    ]
     reduce = Reduce([], lambda acc, x: acc + [x])
 
     source = SyncEmitSource()
@@ -4960,7 +4965,7 @@ def test_parallel_execution_with_large_data():
     assert len(termination_result) == num_records
     for n, result in enumerate(termination_result):
         if num_runnables == 1:
-            assert result == {"data_size": data_size, "n": n}
+            assert result == {"data_size": data_size, "n": n, "gpu": 0}
         else:
-            for runnable_result in result.values():
-                assert runnable_result == {"data_size": data_size, "n": n}
+            for expected_gpu, runnable_result in enumerate(result.values()):
+                assert runnable_result == {"data_size": data_size, "n": n, "gpu": expected_gpu}

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4920,26 +4920,43 @@ def test_invalid_runnable():
         ParallelExecutionRunnable("my_runnable")
 
 
-class RunnableNaiveWithMutation(ParallelExecutionRunnable):
-    execution_mechanism = "naive"
+class RunnableMultiprocessingWithLargeData(ParallelExecutionRunnable):
+    execution_mechanism = "multiprocessing"
+
+    def __init__(self, data_size, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = None
+        self.data_size = data_size
+
+    def init(self):
+        self.data = list(range(self.data_size))
 
     def run(self, data, path):
-        data["n"] += 1
+        data["data_size"] = len(self.data)
         return data
 
 
-def test_event_input_preservation():
-    runnables = [
-        RunnableNaiveWithMutation("x"),
-    ]
+def test_parallel_execution_with_large_data():
+    data_size = 1_000_000
+    num_records = 100
+    num_runnables = 3
+
+    runnables = [RunnableMultiprocessingWithLargeData(data_size, name=f"runnable_{i}") for i in range(num_runnables)]
     reduce = Reduce([], lambda acc, x: acc + [x])
 
     source = SyncEmitSource()
-    source.to(ParallelExecution(runnables)).to(reduce)
+    source.to(ParallelExecution(runnables, max_processes=1)).to(reduce)
 
     controller = source.run()
-    controller.emit({"n": 1})
-    controller.terminate()
-    termination_result = controller.await_termination()
-    termination_result = termination_result[0]
-    assert termination_result == {"n": 2}
+
+    for n in range(num_records):
+        controller.emit({"n": n})
+    termination_result = controller.terminate(wait=True)
+
+    assert len(termination_result) == num_records
+    for n, result in enumerate(termination_result):
+        if num_runnables == 1:
+            assert result == {"data_size": data_size, "n": n}
+        else:
+            for runnable_result in result.values():
+                assert runnable_result == {"data_size": data_size, "n": n}


### PR DESCRIPTION
To avoid serialization of the runnable per event, and to allow the user to allocate resources specific to that runnable (e.g. GPUs).