### PR TITLE
Support microsecond precision in TDEngine databases

### DIFF
--- a/integration/test_tdengine.py
+++ b/integration/test_tdengine.py
@@ -19,8 +19,11 @@ pytestmark = pytest.mark.skipif(not has_tdengine_credentials, reason="Missing TD
 TDEngineData = tuple[taosws.Connection, str, Optional[str], Optional[str], str, str]
 
 
-@pytest.fixture(params=[10])
+@pytest.fixture(params=[("ms", 10), ("us", 10)])
 def tdengine(request: "pytest.FixtureRequest") -> Iterator[TDEngineData]:
+    timestamp_precision = request.param[0]
+    nchar_size = request.param[1]
+
     db_name = "storey"
     supertable_name = "test_supertable"
 
@@ -35,7 +38,7 @@ def tdengine(request: "pytest.FixtureRequest") -> Iterator[TDEngineData]:
         if "Database not exist" not in str(err):
             raise err
 
-    connection.execute(f"CREATE DATABASE {db_name};")
+    connection.execute(f"CREATE DATABASE {db_name} PRECISION '{timestamp_precision}';")
     connection.execute(f"USE {db_name}")
 
     try:
@@ -45,7 +48,7 @@ def tdengine(request: "pytest.FixtureRequest") -> Iterator[TDEngineData]:
             raise err
 
     connection.execute(
-        f"CREATE STABLE {supertable_name} (time TIMESTAMP, my_string NCHAR({request.param})) TAGS (my_int INT);"
+        f"CREATE STABLE {supertable_name} (time TIMESTAMP, my_string NCHAR({nchar_size})) TAGS (my_int INT);"
     )
 
     # Test runs
@@ -136,7 +139,7 @@ def test_tdengine_target(tdengine: TDEngineData, table_col: Optional[str]) -> No
     assert result_list == expected_result
 
 
-@pytest.mark.parametrize("tdengine", [100], indirect=["tdengine"])
+@pytest.mark.parametrize("tdengine", [("ms", 100)], indirect=["tdengine"])
 def test_sql_injection(tdengine: TDEngineData) -> None:
     connection, url, user, password, db_name, supertable_name = tdengine
     # Create another table to be dropped via SQL injection

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -963,6 +963,23 @@ class TDEngineTarget(_Batching, _Writer):
 
         return tags_schema, reg_cols_schema
 
+    def _get_db_timestamp_precision_factor(self) -> int:
+        precision_result = self._connection.query(
+            f"SELECT `precision` FROM information_schema.ins_databases WHERE name='{self._database}'"
+        )
+        precision_result_list = list(precision_result)
+        if not precision_result_list:
+            # Should not happen at this point, as we already executed USE database
+            raise TDEngineValueError(f"Database '{self._database}' not found")
+        precision_str = precision_result_list[0][0]
+        exp_factors = {"ms": 3, "us": 6, "ns": 9}
+        exp_factor = exp_factors.get(precision_str)
+        if exp_factor is None:
+            # Should never happen, as the database should be configured with one of the supported precisions.
+            # Might happen if TDengine changes the precision values.
+            raise TDEngineValueError(f"Unsupported timestamp precision '{precision_str}'")
+        return 10**exp_factor
+
     def _init(self) -> None:
         import taosws
 
@@ -979,6 +996,7 @@ class TDEngineTarget(_Batching, _Writer):
         self._number_of_tags = len(self._tags_schema)
         self._number_of_reg_cols = len(self._reg_cols_schema)
         self._sql_template = self._get_sql_template()
+        self._ts_precision_factor = self._get_db_timestamp_precision_factor()
 
     def _event_to_batch_entry(self, event):
         return self._event_to_writer_entry(event)
@@ -1001,19 +1019,16 @@ class TDEngineTarget(_Batching, _Writer):
     ) -> list["taosws.PyTagView"]:
         return [tag_func(event.get(tag_name)) for tag_name, tag_func in tags_schema]
 
-    @staticmethod
-    def _raw_value_to_value(value):
+    def _raw_value_to_value(self, value):
         if isinstance(value, datetime.datetime):
-            # We currently support only the default millisecond precision
-            return int(value.timestamp() * 1000)
+            return int(value.timestamp() * self._ts_precision_factor)
         return value
 
-    @classmethod
     def _get_batch_values(
-        cls, reg_cols_schema: list[tuple[str, Callable[[list], "taosws.PyColumnView"]]], batch: list[dict]
+        self, reg_cols_schema: list[tuple[str, Callable[[list], "taosws.PyColumnView"]]], batch: list[dict]
     ) -> list["taosws.PyColumnView"]:
         return [
-            col_func([cls._raw_value_to_value(event.get(col_name)) for event in batch])
+            col_func([self._raw_value_to_value(event.get(col_name)) for event in batch])
             for col_name, col_func in reg_cols_schema
         ]
 


### PR DESCRIPTION
A part of the work on [ML-9067](https://iguazio.atlassian.net/browse/ML-9067) for storey's `TDEngineTarget`.

The possible timestamp precisions in TDEngine are:

* ms - millisecond
* us - microsecond
* ns - nanosecond

See:
https://docs.tdengine.com/tdengine-reference/sql-manual/data-types/#timestamp
https://docs.tdengine.com/tdengine-reference/sql-manual/manage-databases/#create-database

We previously supported only ms - TDEngine's default.

The precision is set for the whole database. It is stored in the metadata database:
https://docs.tdengine.com/tdengine-reference/sql-manual/metadata/#ins_databases

Note: the ns precision is not natural in Python, so I do not expect it to be used.
I tested it while running an MLRun system test, and it works.

[ML-9067]: https://iguazio.atlassian.net/browse/ML-9067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ