### PR TITLE
Remove old check for feature added in 3.2.0

### DIFF
--- a/integration/test_aggregation_integration.py
+++ b/integration/test_aggregation_integration.py
@@ -1138,11 +1138,10 @@ def test_aggregate_and_query_with_different_fixed_windows(setup_teardown_test, p
         ), f"actual did not match expected. \n actual: {actual} \n expected: {expected_results}"
 
 
-@pytest.mark.parametrize("use_parallel_operations", [True, False])
-def test_query_virtual_aggregations_flow(setup_teardown_test, use_parallel_operations):
+def test_query_virtual_aggregations_flow(setup_teardown_test):
     table = Table(
         setup_teardown_test.table_name,
-        setup_teardown_test.driver(use_parallel_operations=use_parallel_operations),
+        setup_teardown_test.driver(),
     )
     controller = build_flow(
         [
@@ -1250,7 +1249,7 @@ def test_query_virtual_aggregations_flow(setup_teardown_test, use_parallel_opera
 
     other_table = Table(
         setup_teardown_test.table_name,
-        setup_teardown_test.driver(use_parallel_operations=use_parallel_operations),
+        setup_teardown_test.driver(),
     )
     controller = build_flow(
         [

--- a/storey/drivers.py
+++ b/storey/drivers.py
@@ -94,7 +94,6 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
         self,
         webapi: Optional[str] = None,
         access_key: Optional[str] = None,
-        use_parallel_operations=True,
         v3io_client_kwargs=None,
     ):
         NeedsV3ioAccess.__init__(self, webapi, access_key)
@@ -107,7 +106,6 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
         self._error_code_string = "ErrorCode"
         self._false_condition_error_code = "16777244"
         self._mtime_header_name = "X-v3io-transaction-verifier"
-        self._parallel_ops = use_parallel_operations
 
     def _lazy_init(self):
         self._closed = False
@@ -220,23 +218,6 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
         additional_data=None,
     ):
         self._lazy_init()
-
-        # test whether server support parallel operations
-        if self._parallel_ops:
-            try:
-                test_expression = "a=init_array(2,'double',0.0);a[0..1]=pmax(a[0..1], a[0..1]);delete(a);"
-                response = await self._v3io_client.kv.update(
-                    container,
-                    table_path,
-                    str(key),
-                    expression=test_expression,
-                    condition="",
-                    raise_for_status=v3io.aio.dataplane.RaiseForStatus.never,
-                )
-                if response.status_code != 200:
-                    self._parallel_ops = False
-            except Exception:
-                pass
 
         should_raise_error = False
         (
@@ -458,7 +439,7 @@ class V3ioDriver(NeedsV3ioAccess, Driver):
         pending_updates = {}
         initialized_attributes = {}
         pexpressions = {}
-        use_parallel = self._parallel_ops
+        use_parallel = True
 
         for name, bucket in aggregation_element.aggregation_buckets.items():
 

--- a/storey/redis_driver.py
+++ b/storey/redis_driver.py
@@ -61,7 +61,6 @@ class RedisDriver(NeedsRedisAccess, Driver):
         redis_client: Optional[Union[redis.Redis, redis.cluster.RedisCluster]] = None,
         key_prefix: str = None,
         redis_url: Optional[str] = None,
-        use_parallel_operations: bool = True,  # unused
     ):
         # if client provided a redis-client object, use it. otherwise store the redis url, and create redis-client
         # upon demand (any access to self.redis)


### PR DESCRIPTION
This check is no longer relevant and causes items to be created prematurely.

[ML-9660](https://iguazio.atlassian.net/browse/ML-9660)

[ML-9660]: https://iguazio.atlassian.net/browse/ML-9660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ