### PR TITLE
Remove usage of `asyncio.Queue._loop` which was removed in python 3.10

### DIFF
--- a/storey/queue.py
+++ b/storey/queue.py
@@ -69,7 +69,7 @@ class SimpleAsyncQueue:
         self._capacity = capacity
         self._deque = collections.deque()
         self._not_empty_futures = collections.deque()
-        self._loop = asyncio.get_running_loop() or asyncio.set_event_loop(None)
+        self._loop = asyncio.get_running_loop()
 
     async def get(self, timeout=None):
         if not self._deque:

--- a/storey/queue.py
+++ b/storey/queue.py
@@ -23,6 +23,7 @@ class AsyncQueue(asyncio.Queue):
 
     async def peek(self):
         while self.empty():
+            self._loop = self._loop or asyncio.get_event_loop()
             getter = self._loop.create_future()
             self._getters.append(getter)
             try:
@@ -68,7 +69,7 @@ class SimpleAsyncQueue:
         self._capacity = capacity
         self._deque = collections.deque()
         self._not_empty_futures = collections.deque()
-        self._loop = asyncio.get_running_loop()
+        self._loop = asyncio.get_running_loop() or asyncio.set_event_loop(None)
 
     async def get(self, timeout=None):
         if not self._deque:

--- a/storey/queue.py
+++ b/storey/queue.py
@@ -23,7 +23,7 @@ class AsyncQueue(asyncio.Queue):
 
     async def peek(self):
         while self.empty():
-            self._loop = self._loop or asyncio.get_event_loop()
+            self._loop = self._loop or asyncio.get_running_loop()
             getter = self._loop.create_future()
             self._getters.append(getter)
             try:

--- a/storey/queue.py
+++ b/storey/queue.py
@@ -23,8 +23,7 @@ class AsyncQueue(asyncio.Queue):
 
     async def peek(self):
         while self.empty():
-            self._loop = self._loop or asyncio.get_running_loop()
-            getter = self._loop.create_future()
+            getter = asyncio.get_running_loop().create_future()
             self._getters.append(getter)
             try:
                 await getter


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-9747
Error due to deprecation of self._loop in asyncio object in python 3.10 and higher.
https://docs.python.org/3.10/whatsnew/3.10.html#deprecated
The loop parameter has been removed from most of [asyncio](https://docs.python.org/3.10/library/asyncio.html#module-asyncio)‘s [high-level API](https://docs.python.org/3.10/library/asyncio-api-index.html) following deprecation in Python 3.8. The motivation behind this change is multifold:

This simplifies the high-level API.

The functions in the high-level API have been implicitly getting the current thread’s running event loop since Python 3.7. There isn’t a need to pass the event loop to the API in most normal use cases.

Event loop passing is error-prone especially when dealing with loops running in different threads.