### PR TITLE
[ParallelExecution] Adding metadata field to event

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1665,14 +1665,12 @@ class ParallelExecution(Flow):
                     )
                 futures.append(future)
             results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(
-                *futures, return_exceptions=self._return_exceptions
+                *futures
             )
             if len(self.runnables) == 1:
                 event.body = results[0].data if results else None
                 if self.monitored:
-                    setattr(
-                        event,
-                        "monitoring_data",
+                    event.monitoring_data = (
                         {
                             "microsec": results[0].runtime,
                             "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
@@ -1694,5 +1692,5 @@ class ParallelExecution(Flow):
                         }
                         for result in results
                     }
-                    setattr(event, "monitoring_data", monitoring_data)
+                    event.monitoring_data = monitoring_data
             return await self._do_downstream(event)

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1664,9 +1664,7 @@ class ParallelExecution(Flow):
                         event.path,
                     )
                 futures.append(future)
-            results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(
-                *futures
-            )
+            results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(*futures)
             if len(self.runnables) == 1:
                 event.body = results[0].data if results else None
                 if self.monitored:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1518,10 +1518,10 @@ class ParallelExecutionRunnable:
         try:
             body = self.run(body, path)
         except Exception as e:
-            if not self._raise_exception:
-                body = {"error": f"{type(e)}: {e}"}
-            else:
+            if self._raise_exception:
                 raise e
+            else:
+                body = {"error": f"{type(e)}: {e}"}
         end = time.monotonic()
         return _ParallelExecutionRunnableResult(self.name, body, end - start, timestamp)
 
@@ -1531,10 +1531,10 @@ class ParallelExecutionRunnable:
         try:
             body = await self.run_async(body, path)
         except Exception as e:
-            if not self._raise_exception:
-                body = {"error": f"{type(e)}: {e}"}
-            else:
+            if self._raise_exception:
                 raise e
+            else:
+                body = {"error": f"{type(e)}: {e}"}
         end = time.monotonic()
         return _ParallelExecutionRunnableResult(self.name, body, end - start, timestamp)
 
@@ -1669,7 +1669,7 @@ class ParallelExecution(Flow):
             if len(self.runnables) == 1:
                 event.body = results[0].data if results else None
                 if self.monitored:
-                    event.monitoring_data = (
+                    event._monitoring_data = (
                         {
                             "microsec": results[0].runtime,
                             "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
@@ -1679,7 +1679,7 @@ class ParallelExecution(Flow):
             else:
                 event.body = {result.runnable_name: result.data for result in results}
                 if self.monitored:
-                    event.monitoring_data = {
+                    event._monitoring_data = {
                         result.runnable_name: {
                             "microsec": result.runtime,
                             "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1443,10 +1443,11 @@ class Context:
 
 
 class _ParallelExecutionRunnableResult:
-    def __init__(self, runnable_name: str, data: Any, runtime: float):
+    def __init__(self, runnable_name: str, data: Any, runtime: float, timestamp: datetime.datetime):
         self.runnable_name = runnable_name
         self.data = data
         self.runtime = runtime
+        self.timestamp = timestamp
 
 
 parallel_execution_mechanisms = ("process_pool", "dedicated_process", "thread_pool", "asyncio", "naive")
@@ -1485,6 +1486,7 @@ class ParallelExecutionRunnable:
                 '"process_pool", "dedicated_process", "thread_pool", "asyncio", "naive"'
             )
         self.name = name
+        self._raise_exception = kwargs.get("raise_exception", True)
 
     def init(self) -> None:
         """Override this method to add initialization logic."""
@@ -1511,16 +1513,30 @@ class ParallelExecutionRunnable:
         return body
 
     def _run(self, body: Any, path: str) -> Any:
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         start = time.monotonic()
-        body = self.run(body, path)
+        try:
+            body = self.run(body, path)
+        except Exception as e:
+            if not self._raise_exception:
+                body = {"error": str(e)}
+            else:
+                raise e
         end = time.monotonic()
-        return _ParallelExecutionRunnableResult(self.name, body, end - start)
+        return _ParallelExecutionRunnableResult(self.name, body, end - start, timestamp)
 
     async def _async_run(self, body: Any, path: str) -> Any:
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         start = time.monotonic()
-        body = await self.run_async(body, path)
+        try:
+            body = await self.run_async(body, path)
+        except Exception as e:
+            if not self._raise_exception:
+                body = {"error": str(e)}
+            else:
+                raise e
         end = time.monotonic()
-        return _ParallelExecutionRunnableResult(self.name, body, end - start)
+        return _ParallelExecutionRunnableResult(self.name, body, end - start, timestamp)
 
 
 _sval = None
@@ -1565,6 +1581,8 @@ class ParallelExecution(Flow):
         self.max_threads = max_threads or 32
 
         self._process_executor_by_runnable_name = {}
+
+        self.monitored = kwargs.get("track", False)
 
     def select_runnables(self, event) -> Optional[Union[list[str], list[ParallelExecutionRunnable]]]:
         """
@@ -1646,9 +1664,35 @@ class ParallelExecution(Flow):
                         event.path,
                     )
                 futures.append(future)
-            results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(*futures)
+            results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(
+                *futures, return_exceptions=self._return_exceptions
+            )
             if len(self.runnables) == 1:
                 event.body = results[0].data if results else None
+                if self.monitored:
+                    setattr(
+                        event,
+                        "monitoring_data",
+                        {
+                            "microsec": results[0].runtime,
+                            "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
+                            "error": event.body.get("error") if isinstance(event.body, dict) else None,
+                        },
+                    )
             else:
                 event.body = {result.runnable_name: result.data for result in results}
+                if self.monitored:
+                    monitoring_data = {
+                        result.runnable_name: {
+                            "microsec": result.runtime,
+                            "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),
+                            "error": (
+                                event.body.get(result.runnable_name).get("error")
+                                if isinstance(event.body.get(result.runnable_name), dict)
+                                else None
+                            ),
+                        }
+                        for result in results
+                    }
+                    setattr(event, "monitoring_data", monitoring_data)
             return await self._do_downstream(event)

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1479,14 +1479,14 @@ class ParallelExecutionRunnable:
     execution_mechanism: Optional[str] = None
 
     # ignore unused keyword arguments such as context which may be passed in by mlrun
-    def __init__(self, name: str, **kwargs):
+    def __init__(self, name: str, raise_exception: bool = True, **kwargs):
         if self.execution_mechanism not in parallel_execution_mechanisms:
             raise ValueError(
                 "ParallelExecutionRunnable's execution_mechanism attribute must be overridden with one of: "
                 '"process_pool", "dedicated_process", "thread_pool", "asyncio", "naive"'
             )
         self.name = name
-        self._raise_exception = kwargs.get("raise_exception", True)
+        self._raise_exception = raise_exception
 
     def init(self) -> None:
         """Override this method to add initialization logic."""
@@ -1519,7 +1519,7 @@ class ParallelExecutionRunnable:
             body = self.run(body, path)
         except Exception as e:
             if not self._raise_exception:
-                body = {"error": str(e)}
+                body = {"error": f"{type(e)}: {e}"}
             else:
                 raise e
         end = time.monotonic()
@@ -1532,7 +1532,7 @@ class ParallelExecutionRunnable:
             body = await self.run_async(body, path)
         except Exception as e:
             if not self._raise_exception:
-                body = {"error": str(e)}
+                body = {"error": f"{type(e)}: {e}"}
             else:
                 raise e
         end = time.monotonic()
@@ -1567,6 +1567,7 @@ class ParallelExecution(Flow):
         runnables: list[ParallelExecutionRunnable],
         max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,
+        monitored: Optional[bool] = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1582,7 +1583,7 @@ class ParallelExecution(Flow):
 
         self._process_executor_by_runnable_name = {}
 
-        self.monitored = kwargs.get("track", False)
+        self.monitored = monitored
 
     def select_runnables(self, event) -> Optional[Union[list[str], list[ParallelExecutionRunnable]]]:
         """
@@ -1678,7 +1679,7 @@ class ParallelExecution(Flow):
             else:
                 event.body = {result.runnable_name: result.data for result in results}
                 if self.monitored:
-                    monitoring_data = {
+                    event.monitoring_data = {
                         result.runnable_name: {
                             "microsec": result.runtime,
                             "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),
@@ -1690,5 +1691,4 @@ class ParallelExecution(Flow):
                         }
                         for result in results
                     }
-                    event.monitoring_data = monitoring_data
             return await self._do_downstream(event)

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1567,7 +1567,6 @@ class ParallelExecution(Flow):
         runnables: list[ParallelExecutionRunnable],
         max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,
-        monitored: Optional[bool] = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1582,8 +1581,6 @@ class ParallelExecution(Flow):
         self.max_threads = max_threads or 32
 
         self._process_executor_by_runnable_name = {}
-
-        self.monitored = monitored
 
     def select_runnables(self, event) -> Optional[Union[list[str], list[ParallelExecutionRunnable]]]:
         """
@@ -1668,27 +1665,19 @@ class ParallelExecution(Flow):
             results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(*futures)
             if len(self.runnables) == 1:
                 event.body = results[0].data if results else None
-                if self.monitored:
-                    event._monitoring_data = (
-                        {
-                            "microsec": results[0].runtime,
-                            "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
-                            "error": event.body.get("error") if isinstance(event.body, dict) else None,
-                        },
-                    )
+                event._metadata = (
+                    {
+                        "microsec": results[0].runtime,
+                        "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
+                    },
+                )
             else:
                 event.body = {result.runnable_name: result.data for result in results}
-                if self.monitored:
-                    event._monitoring_data = {
-                        result.runnable_name: {
-                            "microsec": result.runtime,
-                            "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),
-                            "error": (
-                                event.body.get(result.runnable_name).get("error")
-                                if isinstance(event.body.get(result.runnable_name), dict)
-                                else None
-                            ),
-                        }
-                        for result in results
+                event._metadata = {
+                    result.runnable_name: {
+                        "microsec": result.runtime,
+                        "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),
                     }
+                    for result in results
+                }
             return await self._do_downstream(event)


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-9892

Includes:
1. Allow `ParallelExecutionRunnable` raise_error behavior allowing catching errors in run
2. Adding field to `_ParallelExecutionRunnableResult` for timestamp of the run.
3. Adding field `monitoring_data` to the event output from `ParallelExecution:_do`