### PR TITLE
[ParallelExecution] Update `event._metadata` dictionary instead of overwriting it

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1782,7 +1782,7 @@ class ParallelExecution(Flow):
     def preprocess_event(self, event):
         """
         Given an event, preprocess it with user code.
-        runs before the runnable selector.
+        Runs before the runnable selector.
         Should return the new enriched event.
         :param event: Event object
         """

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1591,6 +1591,14 @@ class ParallelExecution(Flow):
         """
         pass
 
+    def enrich_event(self, event):
+        """
+        Given an event, enriches it with user code.
+        Should return the new enriched event.
+        :param event: Event object
+        """
+        return event
+
     def _init(self):
         super()._init()
         num_processes = 0
@@ -1628,6 +1636,7 @@ class ParallelExecution(Flow):
         if event is _termination_obj:
             return await self._do_downstream(_termination_obj)
         else:
+            event = self.enrich_event(event)
             runnables = self.select_runnables(event)
             if runnables is None:
                 runnables = self.runnables

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1665,19 +1665,23 @@ class ParallelExecution(Flow):
             results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(*futures)
             if len(self.runnables) == 1:
                 event.body = results[0].data if results else None
-                event._metadata = (
-                    {
-                        "microsec": results[0].runtime,
-                        "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
-                    },
-                )
+
+                metadata = {
+                    "microsec": results[0].runtime,
+                    "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
+                }
             else:
                 event.body = {result.runnable_name: result.data for result in results}
-                event._metadata = {
+                metadata = {
                     result.runnable_name: {
                         "microsec": result.runtime,
                         "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),
                     }
                     for result in results
                 }
+
+            if hasattr(event, "_metadata") and isinstance(event._metadata, dict):
+                event._metadata.update(metadata)
+            else:
+                event._metadata = metadata
             return await self._do_downstream(event)

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1779,9 +1779,10 @@ class ParallelExecution(Flow):
         """
         pass
 
-    def enrich_event(self, event):
+    def preprocess_event(self, event):
         """
-        Given an event, enriches it with user code.
+        Given an event, preprocess it with user code.
+        runs before the runnable selector.
         Should return the new enriched event.
         :param event: Event object
         """
@@ -1804,7 +1805,7 @@ class ParallelExecution(Flow):
         if event is _termination_obj:
             return await self._do_downstream(_termination_obj)
         else:
-            event = self.enrich_event(event)
+            event = self.preprocess_event(event)
             runnables = self.select_runnables(event)
             if runnables is None:
                 runnables = self.runnables

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4969,3 +4969,62 @@ def test_parallel_execution_with_large_data():
         else:
             for expected_gpu, runnable_result in enumerate(result.values()):
                 assert runnable_result == {"data_size": data_size, "n": n, "gpu": expected_gpu}
+
+
+def test_enrichment():
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
+    busy_wait_dedicated.execution_mechanism = "dedicated_process"
+
+    runnables = [
+        RunnableWithError("error"),
+        busy_wait_pool,
+        busy_wait_dedicated,
+        RunnableSleep("sleep1"),
+        RunnableSleep("sleep2"),
+        RunnableAsyncSleep("asleep1"),
+        RunnableAsyncSleep("asleep2"),
+        RunnableAsyncSleep("naive"),
+    ]
+
+    class MyParallelExecution(ParallelExecution):
+
+        def enrich_event(self, event):
+            event._metadata = {"name": self.name}
+            return event
+
+        def select_runnables(self, event):
+            return [runnable.name for runnable in runnables if runnable.name != "error"]
+
+    parallel_execution = MyParallelExecution(runnables, full_event=True)
+    reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
+
+    source = SyncEmitSource()
+    source.to(parallel_execution).to(reduce)
+
+    start = time.monotonic()
+    controller = source.run()
+    controller.emit(0)
+    controller.terminate()
+    termination_result = controller.await_termination()
+    end = time.monotonic()
+
+    assert end - start < 6
+    result = termination_result[0].body
+    total_metadata = termination_result[0]._metadata
+
+    assert result == {
+        "asleep1": 1,
+        "asleep2": 1,
+        "busy1": 1,
+        "busy2": 1,
+        "naive": 1,
+        "sleep1": 1,
+        "sleep2": 1,
+    }
+    assert (
+        "name" in total_metadata and total_metadata.pop("name") == "MyParallelExecution"
+    ), "Expected name in _metadata field"
+    assert all(
+        list(("when" in metadata and "microsec" in metadata) for metadata in total_metadata.values())
+    ), "Expected _metadata to include 'when' and 'microsec' fields "

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5033,7 +5033,6 @@ def test_enrichment():
             event._metadata = {"name": self.name}
             return event
 
-
     parallel_execution = MyParallelExecution(runnables)
     reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5056,10 +5056,9 @@ def test_enrichment():
     assert result == {
         "busy1": 1,
         "busy2": 1,
-
     }
     assert (
-            "name" in total_metadata and total_metadata.pop("name") == "MyParallelExecution"
+        "name" in total_metadata and total_metadata.pop("name") == "MyParallelExecution"
     ), "Expected name in _metadata field"
     assert all(
         list(("when" in metadata and "microsec" in metadata) for metadata in total_metadata.values())
@@ -5101,7 +5100,6 @@ def test_without_enrichment():
     assert result == {
         "busy1": 1,
         "busy2": 1,
-
     }
     assert all(
         list(("when" in metadata and "microsec" in metadata) for metadata in total_metadata.values())

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5029,14 +5029,12 @@ def test_enrichment():
 
     class MyParallelExecution(ParallelExecution):
 
-        def enrich_event(self, event):
+        def preprocess_event(self, event):
             event._metadata = {"name": self.name}
             return event
 
-        def select_runnables(self, event):
-            return [runnable.name for runnable in runnables if runnable.name != "error"]
 
-    parallel_execution = MyParallelExecution(runnables, full_event=True)
+    parallel_execution = MyParallelExecution(runnables)
     reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
 
     source = SyncEmitSource()
@@ -5065,7 +5063,7 @@ def test_enrichment():
     ), "Expected _metadata to include 'when' and 'microsec' fields "
 
 
-def test_without_enrichment():
+def test_metadata_without_enrichment():
     busy_wait_pool = RunnableBusyWait("busy1")
     busy_wait_dedicated = RunnableBusyWait("busy2")
     busy_wait_dedicated.execution_mechanism = "dedicated_process"
@@ -5075,12 +5073,7 @@ def test_without_enrichment():
         busy_wait_dedicated,
     ]
 
-    class MyParallelExecution(ParallelExecution):
-
-        def select_runnables(self, event):
-            return [runnable.name for runnable in runnables if runnable.name != "error"]
-
-    parallel_execution = MyParallelExecution(runnables, full_event=True)
+    parallel_execution = ParallelExecution(runnables)
     reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
 
     source = SyncEmitSource()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5015,3 +5015,94 @@ def test_parallel_execution_with_shared():
         "busy2": 1,
         "thread1": 1,
     }
+
+
+def test_enrichment():
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
+    busy_wait_dedicated.execution_mechanism = "dedicated_process"
+
+    runnables = [
+        busy_wait_pool,
+        busy_wait_dedicated,
+    ]
+
+    class MyParallelExecution(ParallelExecution):
+
+        def enrich_event(self, event):
+            event._metadata = {"name": self.name}
+            return event
+
+        def select_runnables(self, event):
+            return [runnable.name for runnable in runnables if runnable.name != "error"]
+
+    parallel_execution = MyParallelExecution(runnables, full_event=True)
+    reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
+
+    source = SyncEmitSource()
+    source.to(parallel_execution).to(reduce)
+
+    start = time.monotonic()
+    controller = source.run()
+    controller.emit(0)
+    controller.terminate()
+    termination_result = controller.await_termination()
+    end = time.monotonic()
+
+    assert end - start < 3
+    result = termination_result[0].body
+    total_metadata = termination_result[0]._metadata
+
+    assert result == {
+        "busy1": 1,
+        "busy2": 1,
+
+    }
+    assert (
+            "name" in total_metadata and total_metadata.pop("name") == "MyParallelExecution"
+    ), "Expected name in _metadata field"
+    assert all(
+        list(("when" in metadata and "microsec" in metadata) for metadata in total_metadata.values())
+    ), "Expected _metadata to include 'when' and 'microsec' fields "
+
+
+def test_without_enrichment():
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
+    busy_wait_dedicated.execution_mechanism = "dedicated_process"
+
+    runnables = [
+        busy_wait_pool,
+        busy_wait_dedicated,
+    ]
+
+    class MyParallelExecution(ParallelExecution):
+
+        def select_runnables(self, event):
+            return [runnable.name for runnable in runnables if runnable.name != "error"]
+
+    parallel_execution = MyParallelExecution(runnables, full_event=True)
+    reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
+
+    source = SyncEmitSource()
+    source.to(parallel_execution).to(reduce)
+
+    start = time.monotonic()
+    controller = source.run()
+    controller.emit(0)
+    controller.terminate()
+    termination_result = controller.await_termination()
+    end = time.monotonic()
+
+    assert end - start < 3
+    result = termination_result[0].body
+    total_metadata = termination_result[0]._metadata
+
+    assert result == {
+        "busy1": 1,
+        "busy2": 1,
+
+    }
+    assert all(
+        list(("when" in metadata and "microsec" in metadata) for metadata in total_metadata.values())
+    ), "Expected _metadata to include 'when' and 'microsec' fields "


### PR DESCRIPTION
Relates to https://iguazio.atlassian.net/browse/ML-9892
As part of connecting to monitoring there is a need to allow metadata creation in mlrun side before calling the _do method