### PR TITLE
Move execution mechanism from `ParallelExecutionRunnable` to `ParallelExecution` itself

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1494,36 +1494,16 @@ class ParallelExecutionMechanisms(str, enum.Enum):
     def validate(execution_mechanism: str) -> None:
         if execution_mechanism not in ParallelExecutionMechanisms.all():
             raise ValueError(
-                "ParallelExecutionRunnable's execution_mechanism attribute must be overridden with one of: "
-                f"{ParallelExecutionMechanisms.all()}"
+                f"ParallelExecutionRunnable's execution_mechanism must be one of: {ParallelExecutionMechanisms.all()}"
             )
 
 
 class ParallelExecutionRunnable:
     """
-    Runnable to be run by a ParallelExecution step. On instantiation, the execution_mechanism constructor parameter
-        must be one of:
-    * "process_pool" – To run in a separate process from a process pool. This is appropriate for CPU or GPU intensive
-        tasks as they would otherwise block the main process by holding Python's Global Interpreter Lock (GIL).
-    * "dedicated_process" – To run in a separate dedicated process. This is appropriate for CPU or GPU intensive tasks
-        that also require significant Runnable-specific initialization (e.g. a large model).
-    * "thread_pool" – To run in a separate thread. This is appropriate for blocking I/O tasks, as they would otherwise
-        block the main event loop thread.
-    * "asyncio" – To run in an asyncio task. This is appropriate for I/O tasks that use asyncio, allowing the event
-        loop to continue running while waiting for a response.
-    * "shared_executor" – Reuses an external executor (typically managed by the flow or context) to execute the
-        runnable. Should be used only if you have multiply `ParallelExecution` in the same flow and especially
-        useful when:
-        - You want to share a heavy resource like a large model loaded onto a GPU.
-        - You want to centralize task scheduling or coordination for multiple lightweight tasks.
-        - You aim to minimize overhead from creating new executors or processes/threads per runnable.
-      The runnable is expected to be pre-initialized and reused across events, enabling efficient use of memory and
-      hardware accelerators.
-    * "naive" – To run in the main event loop. This is appropriate only for trivial computation and/or file I/O. It
-        means that the runnable will not actually be run in parallel to anything else.
+    Runnable to be run by a ParallelExecution step.
 
-    Subclasses must also override the run() method, or run_async() when execution_mechanism="asyncio", with user code
-    that handles the event and returns a result.
+    Subclasses must also override the run() method, or run_async() in order to support execution_mechanism="asyncio",
+    with user code that handles the event and returns a result.
 
     Subclasses may optionally override the init() method if the user's implementation of run() requires prior
     initialization.
@@ -1532,10 +1512,8 @@ class ParallelExecutionRunnable:
     """
 
     # ignore unused keyword arguments such as context which may be passed in by mlrun
-    def __init__(self, name: str, execution_mechanism: str, raise_exception: bool = True, **kwargs):
-        ParallelExecutionMechanisms.validate(execution_mechanism)
+    def __init__(self, name: str, raise_exception: bool = True, **kwargs):
         self.name = name
-        self.execution_mechanism = execution_mechanism
         self._raise_exception = raise_exception
 
     def init(self) -> None:
@@ -1619,6 +1597,7 @@ class RunnableExecutor:
         pool_factor: Optional[int] = None,
     ):
         self._runnable_by_name: dict[str, ParallelExecutionRunnable] = {}
+        self._execution_mechanism_by_runnable_name: dict[str, str] = {}
         self.max_processes = max_processes or os.cpu_count() or 16
         self.max_threads = max_threads or 32
         self.pool_factor = pool_factor or 1
@@ -1629,16 +1608,18 @@ class RunnableExecutor:
         self._mp_context = None
         self._executors = {}
 
-    def add_runnable(self, runnable: ParallelExecutionRunnable) -> None:
+    def add_runnable(self, runnable: ParallelExecutionRunnable, execution_mechanism: str) -> None:
         """
         Registers a new runnable instance.
 
         :param runnable: A `ParallelExecutionRunnable` instance.
+        :param execution_mechanism: Execution mechanism (See `ParallelExecution`).
 
         :raises ValueError: If a runnable with the same name is already registered.
         """
         if runnable.name not in self._runnable_by_name:
             self._runnable_by_name[runnable.name] = runnable
+            self._execution_mechanism_by_runnable_name[runnable.name] = execution_mechanism
         else:
             raise ValueError(f"ParallelExecutionRunnable name '{runnable.name}' is not unique")
 
@@ -1659,10 +1640,12 @@ class RunnableExecutor:
         runnable.init()
         self._runnable_by_name[runnable.name] = runnable
 
-        if runnable.execution_mechanism == ParallelExecutionMechanisms.process_pool:
+        execution_mechanism = self._execution_mechanism_by_runnable_name[runnable.name]
+
+        if execution_mechanism == ParallelExecutionMechanisms.process_pool:
             self.num_processes += 1
 
-        elif runnable.execution_mechanism == ParallelExecutionMechanisms.dedicated_process:
+        elif execution_mechanism == ParallelExecutionMechanisms.dedicated_process:
             self._mp_context = self._mp_context or multiprocessing.get_context("spawn")
             self._process_executor_by_runnable_name[runnable.name] = ProcessPoolExecutor(
                 max_workers=1,
@@ -1671,11 +1654,11 @@ class RunnableExecutor:
                 initargs=(runnable,),
             )
 
-        elif runnable.execution_mechanism == ParallelExecutionMechanisms.thread_pool:
+        elif execution_mechanism == ParallelExecutionMechanisms.thread_pool:
             self.num_threads += 1
 
-        elif runnable.execution_mechanism not in ParallelExecutionMechanisms.single_thread():
-            raise ValueError(f"Unsupported execution mechanism: {runnable.execution_mechanism}")
+        elif execution_mechanism not in ParallelExecutionMechanisms.single_thread():
+            raise ValueError(f"Unsupported execution mechanism: {execution_mechanism}")
 
     def init_executors(self):
         """
@@ -1716,18 +1699,18 @@ class RunnableExecutor:
         if id(runnable) in runnables_encountered:
             raise ValueError(f"select_runnables() returned more than one outlet named '{runnable.name}'")
 
+        execution_mechanism = self._execution_mechanism_by_runnable_name[runnable.name]
+
         input = (
-            event.body
-            if runnable.execution_mechanism in ParallelExecutionMechanisms.process()
-            else copy.deepcopy(event.body)
+            event.body if execution_mechanism in ParallelExecutionMechanisms.process() else copy.deepcopy(event.body)
         )
 
-        if runnable.execution_mechanism == ParallelExecutionMechanisms.asyncio:
+        if execution_mechanism == ParallelExecutionMechanisms.asyncio:
             future = asyncio.get_running_loop().create_task(runnable._async_run(input, event.path))
-        elif runnable.execution_mechanism == ParallelExecutionMechanisms.naive:
+        elif execution_mechanism == ParallelExecutionMechanisms.naive:
             future = asyncio.get_running_loop().create_future()
             future.set_result(runnable._run(input, event.path))
-        elif runnable.execution_mechanism == ParallelExecutionMechanisms.dedicated_process:
+        elif execution_mechanism == ParallelExecutionMechanisms.dedicated_process:
             executor = self._process_executor_by_runnable_name[runnable.name]
             future = asyncio.get_running_loop().run_in_executor(
                 executor,
@@ -1736,7 +1719,7 @@ class RunnableExecutor:
                 event.path,
             )
         else:
-            executor = self._executors[runnable.execution_mechanism]
+            executor = self._executors[execution_mechanism]
             future = asyncio.get_running_loop().run_in_executor(
                 executor,
                 runnable._run,
@@ -1751,6 +1734,26 @@ class ParallelExecution(Flow):
     Runs multiple jobs in parallel for each event.
 
     :param runnables: A list of ParallelExecutionRunnable instances.
+    :param execution_mechanism_by_runnable_name: Mapping from each runnable name to the execution_mechanism that should
+        run it. Must be one of:
+    * "process_pool" – To run in a separate process from a process pool. This is appropriate for CPU or GPU intensive
+        tasks as they would otherwise block the main process by holding Python's Global Interpreter Lock (GIL).
+    * "dedicated_process" – To run in a separate dedicated process. This is appropriate for CPU or GPU intensive tasks
+        that also require significant Runnable-specific initialization (e.g. a large model).
+    * "thread_pool" – To run in a separate thread. This is appropriate for blocking I/O tasks, as they would otherwise
+        block the main event loop thread.
+    * "asyncio" – To run in an asyncio task. This is appropriate for I/O tasks that use asyncio, allowing the event
+        loop to continue running while waiting for a response.
+    * "shared_executor" – Reuses an external executor (typically managed by the flow or context) to execute the
+        runnable. Should be used only if you have multiply `ParallelExecution` in the same flow and especially
+        useful when:
+        - You want to share a heavy resource like a large model loaded onto a GPU.
+        - You want to centralize task scheduling or coordination for multiple lightweight tasks.
+        - You aim to minimize overhead from creating new executors or processes/threads per runnable.
+      The runnable is expected to be pre-initialized and reused across events, enabling efficient use of memory and
+      hardware accelerators.
+    * "naive" – To run in the main event loop. This is appropriate only for trivial computation and/or file I/O. It
+        means that the runnable will not actually be run in parallel to anything else.
     :param max_processes: Maximum number of processes to spawn, not including dedicated ones. Defaults to the number of
       available CPUs, or 16 if number of CPUs can't be determined.
     :param max_threads: Maximum number of threads to start. Defaults to 32.
@@ -1759,6 +1762,7 @@ class ParallelExecution(Flow):
     def __init__(
         self,
         runnables: list[ParallelExecutionRunnable],
+        execution_mechanism_by_runnable_name: dict[str, str],
         max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,
         pool_factor: Optional[int] = None,
@@ -1769,7 +1773,14 @@ class ParallelExecution(Flow):
         if not runnables:
             raise ValueError("ParallelExecution cannot be instantiated without at least one runnable")
 
+        for runnable in runnables:
+            execution_mechanism = execution_mechanism_by_runnable_name.get(runnable.name)
+            if not execution_mechanism:
+                raise ValueError(f"No execution mechanism was specified for runnable '{runnable.name}'")
+            ParallelExecutionMechanisms.validate(execution_mechanism)
+
         self.runnables = runnables
+        self.execution_mechanism_by_runnable_name = execution_mechanism_by_runnable_name
         self.max_processes = max_processes or os.cpu_count() or 16
         self.max_threads = max_threads or 32
         self.pool_factor = pool_factor or 1
@@ -1798,10 +1809,11 @@ class ParallelExecution(Flow):
             max_processes=self.max_processes, max_threads=self.max_threads, pool_factor=self.pool_factor
         )
         for runnable in self.runnables:
-            if runnable.execution_mechanism == ParallelExecutionMechanisms.shared_executor:
+            execution_mechanism = self.execution_mechanism_by_runnable_name[runnable.name]
+            if execution_mechanism == ParallelExecutionMechanisms.shared_executor:
                 self.context.executor.init_runnable(runnable=runnable.name)
             else:
-                self.runnable_executor.add_runnable(runnable=runnable)
+                self.runnable_executor.add_runnable(runnable=runnable, execution_mechanism=execution_mechanism)
                 self.runnable_executor.init_runnable(runnable=runnable)
         self.runnable_executor.init_executors()
 
@@ -1821,7 +1833,10 @@ class ParallelExecution(Flow):
                     if isinstance(runnable, ParallelExecutionRunnable)
                     else self.runnable_executor._runnable_by_name[runnable]
                 )
-                if runnable.execution_mechanism == ParallelExecutionMechanisms.shared_executor:
+                if (
+                    self.execution_mechanism_by_runnable_name[runnable.name]
+                    == ParallelExecutionMechanisms.shared_executor
+                ):
                     future = self.context.executor.run_executor(
                         runnable=runnable.name, runnables_encountered=runnables_encountered, event=event
                     )

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1776,8 +1776,7 @@ class ParallelExecution(Flow):
             raise ValueError("ParallelExecution cannot be instantiated without at least one runnable")
 
         for runnable in runnables:
-            execution_mechanism = execution_mechanism_by_runnable_name.get(runnable.name)
-            if not execution_mechanism:
+            if not (execution_mechanism := execution_mechanism_by_runnable_name.get(runnable.name)):
                 raise ValueError(f"No execution mechanism was specified for runnable '{runnable.name}'")
             ParallelExecutionMechanisms.validate(execution_mechanism)
 

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1494,7 +1494,8 @@ class ParallelExecutionMechanisms(str, enum.Enum):
     def validate(execution_mechanism: str) -> None:
         if execution_mechanism not in ParallelExecutionMechanisms.all():
             raise ValueError(
-                f"ParallelExecutionRunnable's execution_mechanism must be one of: {ParallelExecutionMechanisms.all()}"
+                f"Execution mechanism '{execution_mechanism}' is invalid. It must be one of: "
+                f"{ParallelExecutionMechanisms.all()}"
             )
 
 
@@ -1502,7 +1503,7 @@ class ParallelExecutionRunnable:
     """
     Runnable to be run by a ParallelExecution step.
 
-    Subclasses must also override the run() method, or run_async() in order to support execution_mechanism="asyncio",
+    Subclasses must override the run() method, or run_async() in order to support execution_mechanism="asyncio",
     with user code that handles the event and returns a result.
 
     Subclasses may optionally override the init() method if the user's implementation of run() requires prior
@@ -1617,6 +1618,7 @@ class RunnableExecutor:
 
         :raises ValueError: If a runnable with the same name is already registered.
         """
+        ParallelExecutionMechanisms.validate(execution_mechanism)
         if runnable.name not in self._runnable_by_name:
             self._runnable_by_name[runnable.name] = runnable
             self._execution_mechanism_by_runnable_name[runnable.name] = execution_mechanism

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4832,25 +4832,28 @@ class RunnableWithError(ParallelExecutionRunnable):
 
 def test_parallel_execution_runnable_uniqueness():
     runnables = [
-        RunnableBusyWait("x", "process_pool"),
-        RunnableBusyWait("x", "process_pool"),
+        RunnableBusyWait("x"),
+        RunnableBusyWait("x"),
     ]
-    parallel_execution = ParallelExecution(runnables)
+    parallel_execution = ParallelExecution(runnables, execution_mechanism_by_runnable_name={"x": "process_pool"})
     with pytest.raises(ValueError, match="ParallelExecutionRunnable name 'x' is not unique"):
         parallel_execution._init()
 
 
 def test_select_runnable_uniqueness():
     runnables = [
-        RunnableNaiveNoOp("x", "naive"),
-        RunnableNaiveNoOp("y", "naive"),
+        RunnableNaiveNoOp("x"),
+        RunnableNaiveNoOp("y"),
     ]
 
     class MyParallelExecution(ParallelExecution):
         def select_runnables(self, event):
             return ["x", "x"]
 
-    parallel_execution = MyParallelExecution(runnables)
+    parallel_execution = MyParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={"x": "naive", "y": "naive"},
+    )
 
     source = SyncEmitSource()
     source.to(parallel_execution)
@@ -4863,25 +4866,37 @@ def test_select_runnable_uniqueness():
 
 
 def test_parallel_execution():
-    busy_wait_pool = RunnableBusyWait("busy1", "process_pool")
-    busy_wait_dedicated = RunnableBusyWait("busy2", "dedicated_process")
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
 
     runnables = [
-        RunnableWithError("error", "naive"),
+        RunnableWithError("error"),
         busy_wait_pool,
         busy_wait_dedicated,
-        RunnableSleep("sleep1", "thread_pool"),
-        RunnableSleep("sleep2", "thread_pool"),
-        RunnableAsyncSleep("asleep1", "asyncio"),
-        RunnableAsyncSleep("asleep2", "asyncio"),
-        RunnableNaiveNoOp("naive", "naive"),
+        RunnableSleep("sleep1"),
+        RunnableSleep("sleep2"),
+        RunnableAsyncSleep("asleep1"),
+        RunnableAsyncSleep("asleep2"),
+        RunnableNaiveNoOp("naive"),
     ]
 
     class MyParallelExecution(ParallelExecution):
         def select_runnables(self, event):
             return [runnable.name for runnable in runnables if runnable.name != "error"]
 
-    parallel_execution = MyParallelExecution(runnables)
+    parallel_execution = MyParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={
+            "error": "naive",
+            "busy1": "process_pool",
+            "busy2": "dedicated_process",
+            "sleep1": "thread_pool",
+            "sleep2": "thread_pool",
+            "asleep1": "asyncio",
+            "asleep2": "asyncio",
+            "naive": "naive",
+        },
+    )
     reduce = Reduce([], lambda acc, x: acc + [x])
 
     source = SyncEmitSource()
@@ -4907,12 +4922,16 @@ def test_parallel_execution():
     }
 
 
-def test_invalid_runnable():
+def test_invalid_execution_mechanism():
     with pytest.raises(
         ValueError,
-        match="ParallelExecutionRunnable's execution_mechanism attribute must be overridden with one of:",
+        match="ParallelExecutionRunnable's execution_mechanism must be one of:",
     ):
-        ParallelExecutionRunnable("my_runnable", "nonexistent execution mechanism")
+        runnables = [ParallelExecutionRunnable("my_runnable")]
+        ParallelExecution(
+            runnables,
+            execution_mechanism_by_runnable_name={"my_runnable": "nonexistent execution mechanism"},
+        )
 
 
 class RunnableMultiprocessingWithLargeData(ParallelExecutionRunnable):
@@ -4937,15 +4956,19 @@ def test_parallel_execution_with_large_data():
     num_runnables = 3
 
     runnables = [
-        RunnableMultiprocessingWithLargeData(
-            data_size, gpu_number=i, execution_mechanism="dedicated_process", name=f"runnable_{i}"
-        )
+        RunnableMultiprocessingWithLargeData(data_size, gpu_number=i, name=f"runnable_{i}")
         for i in range(num_runnables)
     ]
     reduce = Reduce([], lambda acc, x: acc + [x])
 
     source = SyncEmitSource()
-    source.to(ParallelExecution(runnables, max_processes=1)).to(reduce)
+    source.to(
+        ParallelExecution(
+            runnables,
+            execution_mechanism_by_runnable_name={runnable.name: "dedicated_process" for runnable in runnables},
+            max_processes=1,
+        )
+    ).to(reduce)
 
     controller = source.run()
 
@@ -4967,13 +4990,13 @@ class RunnableShared(ParallelExecutionRunnable):
 
 
 def test_parallel_execution_with_shared():
-    busy_wait_pool = RunnableBusyWait("busy1", "process_pool")
-    busy_wait_dedicated = RunnableBusyWait("busy2", "dedicated_process")
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
 
     runnables = [
-        RunnableShared("busy2", "shared_executor"),
+        RunnableShared("busy2"),
         busy_wait_pool,
-        RunnableShared("thread1", "shared_executor"),
+        RunnableShared("thread1"),
     ]
 
     class MyParallelExecution(ParallelExecution):
@@ -4985,11 +5008,24 @@ def test_parallel_execution_with_shared():
             self.executor = executor
 
     my_executor = RunnableExecutor()
-    my_executor.add_runnable(busy_wait_dedicated)
-    my_executor.add_runnable(RunnableSleep("thread1", "thread_pool"))
+    my_executor.add_runnable(busy_wait_dedicated, "dedicated_process")
+    my_executor.add_runnable(
+        RunnableSleep(
+            "thread1",
+        ),
+        "thread_pool",
+    )
     my_context = MyContext(executor=my_executor)
 
-    parallel_execution = MyParallelExecution(runnables, context=my_context)
+    parallel_execution = MyParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={
+            "busy1": "process_pool",
+            "busy2": "shared_executor",
+            "thread1": "shared_executor",
+        },
+        context=my_context,
+    )
     reduce = Reduce([], lambda acc, x: acc + [x])
 
     source = SyncEmitSource()
@@ -5012,8 +5048,8 @@ def test_parallel_execution_with_shared():
 
 
 def test_enrichment():
-    busy_wait_pool = RunnableBusyWait("busy1", "process_pool")
-    busy_wait_dedicated = RunnableBusyWait("busy2", "dedicated_process")
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
 
     runnables = [
         busy_wait_pool,
@@ -5026,7 +5062,10 @@ def test_enrichment():
             event._metadata = {"name": self.name}
             return event
 
-    parallel_execution = MyParallelExecution(runnables)
+    parallel_execution = MyParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={"busy1": "process_pool", "busy2": "dedicated_process"},
+    )
     reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
 
     source = SyncEmitSource()
@@ -5056,15 +5095,18 @@ def test_enrichment():
 
 
 def test_metadata_without_enrichment():
-    busy_wait_pool = RunnableBusyWait("busy1", "process_pool")
-    busy_wait_dedicated = RunnableBusyWait("busy2", "dedicated_process")
+    busy_wait_pool = RunnableBusyWait("busy1")
+    busy_wait_dedicated = RunnableBusyWait("busy2")
 
     runnables = [
         busy_wait_pool,
         busy_wait_dedicated,
     ]
 
-    parallel_execution = ParallelExecution(runnables)
+    parallel_execution = ParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={"busy1": "process_pool", "busy2": "dedicated_process"},
+    )
     reduce = Reduce([], lambda acc, x: acc + [x], full_event=True)
 
     source = SyncEmitSource()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4925,7 +4925,7 @@ def test_parallel_execution():
 def test_invalid_execution_mechanism():
     with pytest.raises(
         ValueError,
-        match="ParallelExecutionRunnable's execution_mechanism must be one of:",
+        match="Execution mechanism 'nonexistent execution mechanism' is invalid. It must be one of:",
     ):
         runnables = [ParallelExecutionRunnable("my_runnable")]
         ParallelExecution(


### PR DESCRIPTION
Builds on #573 for [ML-10259](https://iguazio.atlassian.net/browse/ML-10259).

Required for https://github.com/mlrun/mlrun/pull/8183 and https://github.com/mlrun/mlrun/pull/8172 to work together.

[ML-10259]: https://iguazio.atlassian.net/browse/ML-10259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ