### PR TITLE
[Parquet Target] Add single parquet option when using partitioning

### DIFF
--- a/storey/targets.py
+++ b/storey/targets.py
@@ -561,7 +561,7 @@ class ParquetTarget(_Batching, _Writer):
             else:
                 partition_cols = [("$key", 256), "$year", "$month", "$day", "$hour"]
         else:
-            self._single_file_mode = single_file
+            self._single_file_mode = single_file or False
             kwargs["partition_cols"] = partition_cols
 
         if self._single_file_mode and not partition_cols:

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -533,7 +533,7 @@ class ParquetTarget(_Batching, _Writer):
     :param storage_options: Extra options that make sense for a particular storage connection, e.g. host, port,
         username, password, etc., if using a URL that will be parsed by fsspec, e.g., starting
         "s3://”, "gcs://”. Optional.
-    :param single_file: If True, all the partitioned data will be written to a single file named {name}.parquet in
+    :param single_file: If True, all the partitioned data will be written to a single file named target.parquet in
         the specified path. If False (the default), each batch will be written to a separate file with a random uuid.
     :type storage_options: dict
     """
@@ -549,7 +549,7 @@ class ParquetTarget(_Batching, _Writer):
         infer_columns_from_data: Optional[bool] = None,
         max_events: Optional[int] = None,
         flush_after_seconds: Union[int, float, None] = None,
-        single_file: bool = False,
+        single_file: Optional[bool] = None,
         **kwargs,
     ):
         self._single_file_mode = False
@@ -633,12 +633,10 @@ class ParquetTarget(_Batching, _Writer):
             dir_path += "/"
         if dir_path and not self._file_system.exists(dir_path):
             self._file_system.makedirs(dir_path, exist_ok=True)
-        if not self._single_file_mode:
-            file_path = f"{dir_path}{uuid.uuid4()}.parquet"
-        elif self._single_file_mode and not self._partition_cols:
-            file_path = self._path
+        if self._single_file_mode:
+            file_path = f"{dir_path}target.parquet" if self._partition_cols else self._path
         else:
-            file_path = f"{dir_path}{self.name}.parquet"
+            file_path = f"{dir_path}{uuid.uuid4()}.parquet"
         # Remove nanosecs from timestamp columns & index
         for name, _ in df.items():
             if str(df[name].dtype) == "datetime64[ns]":

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -533,6 +533,8 @@ class ParquetTarget(_Batching, _Writer):
     :param storage_options: Extra options that make sense for a particular storage connection, e.g. host, port,
         username, password, etc., if using a URL that will be parsed by fsspec, e.g., starting
         "s3://”, "gcs://”. Optional.
+    :param single_file: If True, all the partitioned data will be written to a single file named {name}.parquet in
+        the specified path. If False (the default), each batch will be written to a separate file with a random uuid.
     :type storage_options: dict
     """
 

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -547,6 +547,7 @@ class ParquetTarget(_Batching, _Writer):
         infer_columns_from_data: Optional[bool] = None,
         max_events: Optional[int] = None,
         flush_after_seconds: Union[int, float, None] = None,
+        single_file: bool = False,
         **kwargs,
     ):
         self._single_file_mode = False
@@ -558,9 +559,10 @@ class ParquetTarget(_Batching, _Writer):
             else:
                 partition_cols = [("$key", 256), "$year", "$month", "$day", "$hour"]
         else:
+            self._single_file_mode = single_file
             kwargs["partition_cols"] = partition_cols
 
-        if self._single_file_mode:
+        if self._single_file_mode and not partition_cols:
             max_events = None
             flush_after_seconds = None
 
@@ -629,7 +631,12 @@ class ParquetTarget(_Batching, _Writer):
             dir_path += "/"
         if dir_path and not self._file_system.exists(dir_path):
             self._file_system.makedirs(dir_path, exist_ok=True)
-        file_path = self._path if self._single_file_mode else f"{dir_path}{uuid.uuid4()}.parquet"
+        if not self._single_file_mode:
+            file_path = f"{dir_path}{uuid.uuid4()}.parquet"
+        elif self._single_file_mode and not self._partition_cols:
+            file_path = self._path
+        else:
+            file_path = f"{dir_path}{self.name}.parquet"
         # Remove nanosecs from timestamp columns & index
         for name, _ in df.items():
             if str(df[name].dtype) == "datetime64[ns]":

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2830,6 +2830,35 @@ def test_write_to_parquet_partition_by_datetime(tmpdir):
     assert read_back_df.equals(expected_df)
 
 
+@pytest.mark.parametrize("max_events", [1, 5])
+def test_write_to_single_partition_parquet(tmpdir, max_events):
+    out_dir = f"{tmpdir}/test_write_to_parquet_partition_by_datetime/{uuid.uuid4().hex}/"
+    columns = ["my_int", "my_string", "id"]
+    controller = build_flow(
+        [
+            SyncEmitSource(),
+            ParquetTarget(out_dir, partition_cols="id", columns=columns, max_events=max_events, single_file=True),
+        ]
+    ).run()
+
+    expected = []
+    for i in range(10):
+        controller.emit([i, f"this is {i}", i % 3])
+        if max_events == 5:
+            expected.append([i, f"this is {i}", i % 3])
+        elif max_events == 1 and i >= 7:
+            expected.append([i, f"this is {i}", i % 3])
+    expected_df = pd.DataFrame(expected, columns=columns)
+    expected_df["id"] = expected_df["id"].astype("int32").astype("category")
+    controller.terminate()
+    controller.await_termination()
+
+    read_back_df = pd.read_parquet(out_dir, columns=columns)
+    read_back_df.sort_values("my_int", inplace=True)
+    read_back_df.reset_index(drop=True, inplace=True)
+    assert read_back_df.equals(expected_df)
+
+
 def test_write_to_parquet_string_as_datetime(tmpdir):
     out_dir = f"{tmpdir}/test_write_to_parquet_string_to_datetime/{uuid.uuid4().hex}/"
     columns = ["my_int", "my_string", "my_datetime"]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2832,12 +2832,13 @@ def test_write_to_parquet_partition_by_datetime(tmpdir):
 
 @pytest.mark.parametrize("max_events", [1, 5])
 def test_write_to_single_partition_parquet(tmpdir, max_events):
-    def check_target_parquets(dir, ids=(0, 1, 2)):
-        expected_files = [os.path.join(dir, f"id={i}", "target.parquet") for i in ids]
+    out_dir = f"{tmpdir}/test_write_to_parquet_partition_by_datetime/"
+
+    def check_target_parquets(ids):
+        expected_files = [os.path.join(out_dir, f"id={i}", "target.parquet") for i in ids]
         missing = [f for f in expected_files if not os.path.exists(f)]
         assert not missing, f"Missing expected parquet files: {missing}"
 
-    out_dir = f"{tmpdir}/test_write_to_parquet_partition_by_datetime/"
     columns = ["my_int", "my_string", "id"]
     flow = build_flow(
         [
@@ -2862,9 +2863,8 @@ def test_write_to_single_partition_parquet(tmpdir, max_events):
     read_back_df = pd.read_parquet(out_dir, columns=columns)
     read_back_df.sort_values("my_int", inplace=True)
     read_back_df.reset_index(drop=True, inplace=True)
-    assert read_back_df.equals(expected_df)
-
-    check_target_parquets(out_dir, ids=(0, 1, 2))
+    pd.testing.assert_frame_equal(read_back_df, expected_df)
+    check_target_parquets(ids=(0, 1, 2))
 
     controller = flow.run()
     expected = []
@@ -2882,8 +2882,8 @@ def test_write_to_single_partition_parquet(tmpdir, max_events):
     read_back_df = pd.read_parquet(out_dir, columns=columns)
     read_back_df.sort_values("my_int", inplace=True)
     read_back_df.reset_index(drop=True, inplace=True)
-    assert read_back_df.equals(expected_df)
-    check_target_parquets(out_dir, ids=(0, 1, 2))
+    pd.testing.assert_frame_equal(read_back_df, expected_df)
+    check_target_parquets(ids=(0, 1, 2))
 
 
 def test_write_to_parquet_string_as_datetime(tmpdir):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2832,15 +2832,21 @@ def test_write_to_parquet_partition_by_datetime(tmpdir):
 
 @pytest.mark.parametrize("max_events", [1, 5])
 def test_write_to_single_partition_parquet(tmpdir, max_events):
-    out_dir = f"{tmpdir}/test_write_to_parquet_partition_by_datetime/{uuid.uuid4().hex}/"
+    def check_target_parquets(dir, ids=(0, 1, 2)):
+        expected_files = [os.path.join(dir, f"id={i}", "target.parquet") for i in ids]
+        missing = [f for f in expected_files if not os.path.exists(f)]
+        assert not missing, f"Missing expected parquet files: {missing}"
+
+    out_dir = f"{tmpdir}/test_write_to_parquet_partition_by_datetime/"
     columns = ["my_int", "my_string", "id"]
-    controller = build_flow(
+    flow = build_flow(
         [
             SyncEmitSource(),
             ParquetTarget(out_dir, partition_cols="id", columns=columns, max_events=max_events, single_file=True),
         ]
-    ).run()
+    )
 
+    controller = flow.run()
     expected = []
     for i in range(10):
         controller.emit([i, f"this is {i}", i % 3])
@@ -2857,6 +2863,27 @@ def test_write_to_single_partition_parquet(tmpdir, max_events):
     read_back_df.sort_values("my_int", inplace=True)
     read_back_df.reset_index(drop=True, inplace=True)
     assert read_back_df.equals(expected_df)
+
+    check_target_parquets(out_dir, ids=(0, 1, 2))
+
+    controller = flow.run()
+    expected = []
+    for i in range(10, 20):
+        controller.emit([i, f"this is {i}", i % 3])
+        if max_events == 5:
+            expected.append([i, f"this is {i}", i % 3])
+        elif max_events == 1 and i >= 17:
+            expected.append([i, f"this is {i}", i % 3])
+    expected_df = pd.DataFrame(expected, columns=columns)
+    expected_df["id"] = expected_df["id"].astype("int32").astype("category")
+    controller.terminate()
+    controller.await_termination()
+
+    read_back_df = pd.read_parquet(out_dir, columns=columns)
+    read_back_df.sort_values("my_int", inplace=True)
+    read_back_df.reset_index(drop=True, inplace=True)
+    assert read_back_df.equals(expected_df)
+    check_target_parquets(out_dir, ids=(0, 1, 2))
 
 
 def test_write_to_parquet_string_as_datetime(tmpdir):


### PR DESCRIPTION
In this case, we save the most recent parquet file in each partitioned directory.
Which parquet file is considered “last” depends on parameters such as `max_event` or `flush_after_seconds`.
