### PR TITLE
[ParallelExecution] Fix regression that caused subprocesses to be forked rather than spawned

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1614,7 +1614,7 @@ class RunnableExecutor:
         self.num_threads = 0
 
         self._process_executor_by_runnable_name = {}
-        self._mp_context = None
+        self._mp_context = multiprocessing.get_context("spawn")
         self._executors = {}
 
     def add_runnable(self, runnable: ParallelExecutionRunnable, execution_mechanism: str) -> None:
@@ -1656,7 +1656,6 @@ class RunnableExecutor:
             self.num_processes += 1
 
         elif execution_mechanism == ParallelExecutionMechanisms.dedicated_process:
-            self._mp_context = self._mp_context or multiprocessing.get_context("spawn")
             self._process_executor_by_runnable_name[runnable.name] = ProcessPoolExecutor(
                 max_workers=1,
                 mp_context=self._mp_context,

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -15,6 +15,7 @@
 import asyncio
 import copy
 import math
+import multiprocessing.context
 import os
 import queue
 import tempfile
@@ -4996,6 +4997,18 @@ def test_parallel_execution_runnable_uniqueness():
     parallel_execution = ParallelExecution(runnables, execution_mechanism_by_runnable_name={"x": "process_pool"})
     with pytest.raises(ValueError, match="ParallelExecutionRunnable name 'x' is not unique"):
         parallel_execution._init()
+
+
+# ML-11128
+@pytest.mark.parametrize("execution_mechanism", ["process_pool", "dedicated_process"])
+def test_parallel_execution_spawn(execution_mechanism):
+    runnables = [
+        RunnableBusyWait("x"),
+    ]
+    parallel_execution = ParallelExecution(runnables, execution_mechanism_by_runnable_name={"x": execution_mechanism})
+    parallel_execution._init()
+    mp_context = parallel_execution.runnable_executor._mp_context
+    assert isinstance(mp_context, multiprocessing.context.SpawnContext)
 
 
 def test_select_runnable_uniqueness():


### PR DESCRIPTION
[ML-11128](https://iguazio.atlassian.net/browse/ML-11128)

[ML-11128]: https://iguazio.atlassian.net/browse/ML-11128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ