### PR TITLE
[Utils] Adding full partition output to `find_partitions`

### DIFF
--- a/storey/sources.py
+++ b/storey/sources.py
@@ -1055,7 +1055,7 @@ class ParquetSource(DataframeSource):
     def _read_filtered_parquet(self, path):
         fs, file_path = url_to_file_system(path, self._storage_options)
 
-        partitions_time_attributes = find_partitions(path, fs)
+        partitions_time_attributes, _ = find_partitions(path, fs)
         filters = []
         find_filters(
             partitions_time_attributes,

--- a/storey/utils.py
+++ b/storey/utils.py
@@ -285,14 +285,14 @@ def find_partitions(url, fs):
         find_partition_helper(inner_dir, fs, partitions)
 
     if fs.isfile(url):
-        return partitions
+        return partitions, partitions
     find_partition_helper(url, fs, partitions)
 
     legal_time_units = ["year", "month", "day", "hour", "minute", "second"]
 
     partitions_time_attributes = [j for j in legal_time_units if j in partitions]
 
-    return partitions_time_attributes
+    return partitions_time_attributes, partitions
 
 
 def find_filters(partitions_time_attributes, start, end, filters, filter_column):

--- a/storey/utils.py
+++ b/storey/utils.py
@@ -263,6 +263,7 @@ def find_partitions(url, fs):
     # inner month partitions).
 
     partitions = []
+    partitions_time_attributes = []
 
     def _is_private(path):
         _, tail = os.path.split(path)
@@ -284,13 +285,12 @@ def find_partitions(url, fs):
         partitions.append(part[0])
         find_partition_helper(inner_dir, fs, partitions)
 
-    if fs.isfile(url):
-        return partitions, partitions
-    find_partition_helper(url, fs, partitions)
+    if not fs.isfile(url):
+        find_partition_helper(url, fs, partitions)
 
-    legal_time_units = ["year", "month", "day", "hour", "minute", "second"]
+        legal_time_units = ["year", "month", "day", "hour", "minute", "second"]
 
-    partitions_time_attributes = [j for j in legal_time_units if j in partitions]
+        partitions_time_attributes = [j for j in legal_time_units if j in partitions]
 
     return partitions_time_attributes, partitions
 


### PR DESCRIPTION
returning full partitions in addition to time partitions from `find_partitions`. allowing partition verification outside of storey

[ML-11277](https://iguazio.atlassian.net/browse/ML-11277)

[ML-11277]: https://iguazio.atlassian.net/browse/ML-11277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ