### PR TITLE
[Table] Fix memory leak when Table is reused across flow cycles

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1134,6 +1134,14 @@ class _Batching(Flow):
 
     async def _do(self, event):
         if event is _termination_obj:
+            # Cancel _timeout_task to prevent memory leak (ML-11518)
+            if self._timeout_task is not None:
+                self._timeout_task.cancel()
+                try:
+                    await self._timeout_task
+                except asyncio.CancelledError:
+                    pass
+                self._timeout_task = None
             await self._emit_all()
             await self._terminate()
             return await self._do_downstream(_termination_obj)

--- a/storey/table.py
+++ b/storey/table.py
@@ -68,6 +68,7 @@ class Table:
         self._aggregations_read_only = False
         self._use_windows_from_schema = False
         self._q = None
+        self._worker_awaitable = None
         self._max_updates_in_flight = max_updates_in_flight
         self._pending_by_key = {}
         self._flush_interval_secs = flush_interval_secs
@@ -179,6 +180,7 @@ class Table:
             self._flush_task = asyncio.get_running_loop().create_task(self._flush_worker())
 
     async def close(self):
+        await self._terminate()
         await self._storage.close()
 
     async def _aggregate(self, key, event, data, timestamp):
@@ -477,7 +479,15 @@ class Table:
                 await self._worker_awaitable
             for value in self._attrs_cache.values():
                 value.lock = None
+            # Clear caches to prevent memory leak (ML-11518)
+            self._attrs_cache.clear()
+            self._changed_keys.clear()
+            self._pending_by_key.clear()
+            self._pending_events.clear()
+            self._aggregates = None
+            self._schema = None
             self._q = None
+            self._worker_awaitable = None
             self._flush_task = None
             self._flush_exception = None
 

--- a/tests/test_table_cleanup.py
+++ b/tests/test_table_cleanup.py
@@ -1,0 +1,115 @@
+# Copyright 2020 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests for Table cleanup on termination.
+"""
+
+import gc
+import tracemalloc
+from datetime import datetime, timedelta
+
+import pytest
+
+from storey import (
+    AggregateByKey,
+    AsyncEmitSource,
+    FieldAggregator,
+    NoopDriver,
+    Reduce,
+    Table,
+    build_flow,
+)
+from storey.dtypes import SlidingWindows
+
+test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
+
+
+def append_return(lst, x):
+    lst.append(x)
+    return lst
+
+
+@pytest.mark.asyncio
+async def test_table_cleanup_on_terminate():
+    """
+    Verify Table properly clears internal state on terminate().
+
+    When a Table is reused across multiple flow cycles (e.g., Kafka rebalancing),
+    internal caches like _attrs_cache, _aggregates, and _schema must be cleared
+    to prevent memory leaks. This test runs 100 cycles and verifies memory
+    stays constant (no linear growth).
+    """
+    tracemalloc.start()
+
+    # Single table reused across cycles (like production model monitoring)
+    table = Table("test", NoopDriver())
+
+    # Warmup cycle to stabilize memory
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            AggregateByKey(
+                [FieldAggregator("col1", "col1", ["sum", "avg"], SlidingWindows(["1h"], "10m"))],
+                table,
+                time_field="time",
+            ),
+            Reduce([], append_return),
+        ]
+    ).run()
+    await controller.emit({"col1": 0, "time": test_base_time}, key="warmup")
+    await controller.terminate(wait=True)
+
+    gc.collect()
+    snapshot_before = tracemalloc.take_snapshot()
+
+    # Run 100 drain cycles - reusing same table (critical for leak detection)
+    for cycle in range(100):
+        # Reset table for reuse (simulates what happens between Kafka rebalances)
+        table._terminated = False
+
+        controller = build_flow(
+            [
+                AsyncEmitSource(),
+                AggregateByKey(
+                    [FieldAggregator("col1", "col1", ["sum", "avg"], SlidingWindows(["1h"], "10m"))],
+                    table,
+                    time_field="time",
+                ),
+                Reduce([], append_return),
+            ]
+        ).run()
+
+        # Emit events with unique keys per cycle (simulates different model endpoints)
+        for i in range(10):
+            event_time = test_base_time + timedelta(minutes=cycle * 10 + i)
+            await controller.emit({"col1": i, "time": event_time}, key=f"endpoint_{cycle}_{i}")
+
+        await controller.terminate(wait=True)
+
+    # Force garbage collection to measure true leaks (not just pending GC)
+    gc.collect()
+    snapshot_after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+
+    # Compare memory growth
+    stats = snapshot_after.compare_to(snapshot_before, "lineno")
+    total_growth = sum(stat.size_diff for stat in stats if stat.size_diff > 0)
+
+    max_growth_bytes = 50 * 1024
+    assert total_growth <= max_growth_bytes, (
+        f"Memory leak detected: {total_growth / 1024:.1f}KB grew after 100 cycles "
+        f"(max allowed: {max_growth_bytes / 1024:.1f}KB). "
+        f"This indicates resources are not being properly cleaned up during termination."
+    )


### PR DESCRIPTION
When a Table is reused across multiple flow cycles (e.g., Kafka rebalancing
in model monitoring), internal caches like _attrs_cache, _aggregates, and
_schema were not being cleared on termination, causing memory to grow
linearly with each cycle.

Changes:
- Clear all internal caches in Table._terminate() to prevent memory leak
- Initialize _worker_awaitable in __init__ to avoid AttributeError
- Call _terminate() from close() to ensure cleanup happens
- Cancel _Batching._timeout_task on flow termination to prevent task leak

The fix ensures memory stays constant when reusing Table instances, which
is critical for long-running streaming applications.

ML-11518