### PR TITLE
Fix memory leak in overlapping drain scenarios (ML-11518)

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -335,6 +335,46 @@ class Flow:
                     return True
         return False
 
+    def _clear_resources(self, visited=None):
+        """
+        Clear circular references and internal state to enable garbage collection.
+
+        This method should be called when a flow is cancelled or terminated abnormally
+        (e.g., overlapping drain during Kafka rebalancing). Storey flows create circular
+        references via _outlets/_inlets that prevent garbage collection if not cleared.
+
+        Subclasses should override this method to clear their specific state, calling
+        super()._clear_resources(visited) first.
+        """
+        if visited is None:
+            visited = set()
+
+        step_id = id(self)
+        if step_id in visited:
+            return
+        visited.add(step_id)
+
+        # Save outlets before clearing for recursion
+        outlets = list(self._outlets)
+        recovery_steps = self._get_recovery_steps()
+
+        # Clear circular references
+        self._outlets = []
+        self._inlets = []
+
+        # Clear context reference
+        self.context = None
+        self.logger = None
+
+        # Clear recovery step references
+        self._recovery_step = None
+
+        # Recurse to outlets and recovery steps
+        for outlet in outlets:
+            outlet._clear_resources(visited)
+        for step in recovery_steps:
+            step._clear_resources(visited)
+
 
 class WithUUID:
     def __init__(self):
@@ -1198,6 +1238,25 @@ class _Batching(Flow):
     async def _emit_all(self):
         for key in list(self._batch.keys()):
             await self._emit_batch(key)
+
+    def _clear_resources(self, visited=None):
+        """Clear batching-specific state in addition to base Flow cleanup."""
+        super()._clear_resources(visited)
+
+        # Clear batch data (all set in _init)
+        self._batch.clear()
+        self._batch_events.clear()
+        self._batch_first_event_time.clear()
+        self._batch_last_event_time.clear()
+        self._batch_start_time.clear()
+
+        # Cancel and clear timeout task
+        if self._timeout_task and not self._timeout_task.done():
+            self._timeout_task.cancel()
+        self._timeout_task = None
+
+        # Clear bound method reference
+        self._extract_key = None
 
 
 class Batch(_Batching, WithUUID):

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -460,12 +460,14 @@ class AsyncFlowController(FlowControllerBase):
         await_result,
         key_field: Optional[str] = None,
         id_field: Optional[str] = None,
+        on_cancel: Optional[Callable[[], None]] = None,
     ):
         super().__init__(key_field, id_field)
         self._emit_fn = emit_fn
         self._loop_task = loop_task
         self._key_field = key_field
         self._await_result = await_result
+        self._on_cancel = on_cancel
 
     async def emit(
         self,
@@ -520,8 +522,19 @@ class AsyncFlowController(FlowControllerBase):
         """
         Awaits the termination of the flow. To be called after terminate. Returns the termination result of the
         flow (if any).
+
+        If the flow was externally cancelled (e.g., due to overlapping drain signals),
+        CancelledError is caught and None is returned instead of propagating the error.
+        This prevents crashes when the Go runtime times out and sends a new drain signal
+        while an existing drain is still in progress (ML-11518).
         """
-        return await self._loop_task
+        try:
+            return await self._loop_task
+        except asyncio.CancelledError:
+            # External cancellation (e.g., overlapping drain) - clean up and return gracefully
+            if self._on_cancel:
+                self._on_cancel()
+            return None
 
 
 async def _commit_handled_events(outstanding_offsets_by_qualified_shard, committer, logger, commit_all=False):
@@ -710,12 +723,33 @@ class AsyncEmitSource(Flow):
         if event is not _termination_obj:
             self._raise_on_error()
 
+    def _clear_resources(self, visited=None):
+        """Clear AsyncEmitSource-specific state in addition to base Flow cleanup."""
+        super()._clear_resources(visited)
+
+        # Drain the queue to release references
+        if hasattr(self, "_q") and self._q:
+            while not self._q.empty():
+                try:
+                    self._q.get_nowait()
+                except Exception:
+                    break
+
+        # Clear exception reference
+        self._ex = None
+
+        # Clear outstanding offsets
+        if hasattr(self, "_outstanding_offsets"):
+            self._outstanding_offsets.clear()
+
     def run(self):
         """Starts the flow"""
         self._closeables = super().run()
         loop_task = asyncio.get_running_loop().create_task(self._run_loop_and_log_unexpected_error())
         has_complete = self._check_step_in_flow(Complete)
-        return AsyncFlowController(self._emit, loop_task, has_complete, self._key_field)
+        return AsyncFlowController(
+            self._emit, loop_task, has_complete, self._key_field, on_cancel=self._clear_resources
+        )
 
 
 class _IterableSource(Flow):

--- a/storey/table.py
+++ b/storey/table.py
@@ -342,11 +342,21 @@ class Table:
             return None
 
     def _set_aggregations_attrs(self, key, element):
+        """Set aggregation attributes for a key.
+
+        ML-11518 fix: Always call _init_flush_task() since it's idempotent.
+
+        Bug flow (before fix):
+        1. _lazy_load_key_with_aggregates() calls _get_lock(key)
+        2. _get_lock(key) creates _CacheElement({}, None) in _attrs_cache
+        3. _set_aggregations_attrs(key, element) sees key exists, skips _init_flush_task()
+        4. _flush_worker never runs
+        """
+        self._init_flush_task()
         if key in self._attrs_cache:
             self._attrs_cache[key].aggregations = element
             self._changed_keys.add(key)
         else:
-            self._init_flush_task()
             self._attrs_cache[key] = _CacheElement({}, element)
 
     def _get_static_attrs(self, key):

--- a/tests/test_aggregate_by_key.py
+++ b/tests/test_aggregate_by_key.py
@@ -3977,3 +3977,40 @@ def test_fixed_window_aggregation_with_first_and_last_aggregates(timestamp):
     assert (
         termination_result == expected
     ), f"actual did not match expected. \n actual: {termination_result} \n expected: {expected}"
+
+
+@pytest.mark.asyncio
+async def test_ml11518_get_lock_precreates_cache_blocking_flush_task_init():
+    """
+    Root cause test for ML-11518: _get_lock() pre-creates _CacheElement before
+    _set_aggregations_attrs() is called, preventing _init_flush_task() from running.
+
+    Bug flow:
+    1. _lazy_load_key_with_aggregates() calls _get_lock(key)
+    2. _get_lock(key) creates _CacheElement({}, None) in _attrs_cache
+    3. _set_aggregations_attrs(key, element) sees key exists, skips _init_flush_task()
+    4. _flush_worker never runs, pending_aggr grows unboundedly
+    """
+    import asyncio
+
+    from storey.table import _CacheElement
+
+    table = Table("test", NoopDriver(), flush_interval_secs=1)
+
+    # Simulate _get_lock pre-creating cache element with aggregations=None
+    table._attrs_cache["test_key"] = _CacheElement({}, None)
+
+    # _set_aggregations_attrs should init flush task now that fix is in place
+    table._set_aggregations_attrs("test_key", object())
+
+    assert table._flush_task is not None, (
+        "BUG ML-11518: _flush_task not initialized when setting aggregations "
+        "for key pre-created by _get_lock() with aggregations=None"
+    )
+
+    # Cleanup: cancel the flush task
+    table._flush_task.cancel()
+    try:
+        await table._flush_task
+    except asyncio.CancelledError:
+        pass

--- a/tests/test_overlapping_drain.py
+++ b/tests/test_overlapping_drain.py
@@ -1,0 +1,355 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests for overlapping drain scenarios (ML-11518).
+
+When using AsyncEmitSource with Kafka triggers, the Go runtime may timeout
+(rebalanceTimeout) before Python's drain completes. This causes Go to send
+a new drain signal while the old drain is still running.
+
+The issue manifests when:
+1. A drain is in progress (flow is terminating)
+2. The task gets externally cancelled (e.g., by a new drain signal)
+3. CancelledError propagates up and crashes the worker
+
+The fix ensures that:
+1. External cancellation during drain is handled gracefully
+2. Resources are properly cleaned up
+3. No crash occurs
+"""
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from storey import AsyncEmitSource, Map, Reduce, build_flow
+from storey.dtypes import _termination_obj
+
+pytestmark = pytest.mark.asyncio
+
+
+class SlowStep(Map):
+    """A step that takes time to process, simulating slow drain."""
+
+    def __init__(self, delay: float = 0.5, **kwargs):
+        super().__init__(lambda x: x, **kwargs)
+        self._delay = delay
+
+    async def _do(self, event):
+        await asyncio.sleep(self._delay)
+        return await super()._do(event)
+
+
+async def test_overlapping_drain_cancellation():
+    """
+    Test that external cancellation during drain is handled gracefully.
+
+    This simulates the scenario where Go's rebalanceTimeout expires before
+    Python's drain completes, causing the drain task to be cancelled.
+
+    Before the fix: CancelledError would propagate and crash the worker.
+    After the fix: Cancellation is handled gracefully, no crash.
+    """
+    # Build a flow with a slow step to ensure drain takes time
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            SlowStep(delay=0.5),
+            Reduce([], lambda acc, x: acc + [x]),
+        ]
+    ).run()
+
+    # Emit some events
+    for i in range(5):
+        await controller.emit(i)
+
+    # Start termination (drain) but don't wait for it yet
+    await controller._emit_fn(_termination_obj)
+
+    # Simulate external cancellation (like Go timeout triggering new drain)
+    # This is what happens when rebalanceTimeout expires
+    controller._loop_task.cancel()
+
+    # Awaiting a cancelled task raises CancelledError - this is expected asyncio behavior.
+    # The test verifies the flow handles cancellation without crashing.
+    with pytest.raises(asyncio.CancelledError):
+        await controller._loop_task
+
+    # Task should be done (cancelled tasks are a subset of done tasks)
+    assert controller._loop_task.done()
+
+
+async def test_overlapping_drain_with_await_termination():
+    """
+    Test that await_termination handles external cancellation gracefully.
+
+    This tests the more realistic scenario where await_termination() is called
+    and the underlying task gets cancelled.
+    """
+    results = []
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            SlowStep(delay=0.5),
+            Reduce(results, lambda acc, x: acc + [x]),
+        ]
+    ).run()
+
+    # Emit events
+    for i in range(3):
+        await controller.emit(i)
+
+    # Create a task that will call terminate and await_termination
+    async def do_drain():
+        await controller.terminate()
+        await controller.await_termination()
+
+    drain_task = asyncio.create_task(do_drain())
+
+    # Give it a moment to start
+    await asyncio.sleep(0.05)
+
+    # Cancel the drain (simulating Go timeout)
+    drain_task.cancel()
+
+    # Cancelling drain_task raises CancelledError - expected behavior
+    with suppress(asyncio.CancelledError):
+        await drain_task
+
+    # Always clean up controller's loop task (cancel is no-op if already done)
+    controller._loop_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await controller._loop_task
+
+
+async def test_sequential_drains_no_overlap():
+    """
+    Test that sequential (non-overlapping) drains work correctly.
+
+    This is the normal case - drain completes fully before any new operation.
+    """
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            Reduce(0, lambda acc, x: acc + x),
+        ]
+    ).run()
+
+    # First batch
+    for i in range(3):
+        await controller.emit(i)
+
+    # Terminate and wait
+    await controller.terminate()
+    result = await controller.await_termination()
+
+    # Verify result (0 + 0 + 1 + 2 = 3)
+    assert result == 3
+
+
+async def test_drain_with_batching_step():
+    """
+    Test drain with a batching step that holds state.
+
+    Batching steps (_Batching subclasses) hold events in _batch and _batch_events.
+    When drain is cancelled, these must be cleared to prevent memory leaks.
+    """
+    from storey.flow import _Batching
+
+    results = []
+
+    # Create a simple batching step
+    class SimpleBatch(_Batching):
+        def __init__(self, max_events=10, **kwargs):
+            super().__init__(max_events=max_events, **kwargs)
+
+        async def _emit(self, batch, batch_key, batch_time, batch_events, last_event_time=None):
+            results.append(batch)
+
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            SimpleBatch(max_events=100, timeout_secs=60),
+        ]
+    ).run()
+
+    # Emit events (they'll be batched, not flushed yet)
+    for i in range(5):
+        await controller.emit({"value": i})
+
+    # Cancel the task before drain completes
+    controller._loop_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await controller._loop_task
+
+    # The batched events should be cleared (or at least not leak)
+    # In real scenario with fix, resources would be cleaned up
+
+
+async def test_overlapping_drain_memory_leak():
+    """
+    Test that overlapping drains (cancelled mid-drain) don't cause memory leaks.
+
+    When a drain is cancelled mid-flight (simulating Go's rebalanceTimeout expiring),
+    buffers in _Batching._batch may not be cleaned up, causing memory to grow
+    with each interrupted drain cycle.
+
+    The real scenario (ML-11518):
+    1. Same batching step is reused across drain cycles (Kafka trigger pattern)
+    2. Go times out, cancels drain, sends new drain signal
+    3. Old drain's _batch buffer is orphaned if not cleared
+
+    This test reuses the same batching step to detect buffer accumulation.
+    """
+    import gc
+    import tracemalloc
+
+    from storey.flow import _Batching
+
+    class PersistentBatch(_Batching):
+        """Batching step that persists across flow cycles - like real Kafka trigger."""
+
+        def __init__(self, **kwargs):
+            super().__init__(max_events=1000, **kwargs)
+            self.emitted_batches = []
+
+        async def _emit(self, batch, batch_key, batch_time, batch_events, last_event_time=None):
+            self.emitted_batches.append(len(batch))
+
+    # Create persistent batching step - reused across all cycles
+    persistent_batch = PersistentBatch(timeout_secs=60)
+
+    tracemalloc.start()
+
+    # Warmup
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            Reduce([], lambda acc, x: acc + [x]),
+        ]
+    ).run()
+    await controller.emit(0)
+    await controller.terminate()
+    await controller.await_termination()
+
+    gc.collect()
+    snapshot_before = tracemalloc.take_snapshot()
+
+    # Run many interrupted drain cycles with SAME batching step
+    num_cycles = 50
+    for cycle in range(num_cycles):
+        # Rebuild flow but reuse the same persistent_batch step
+        source = AsyncEmitSource()
+        flow = build_flow(
+            [
+                source,
+                SlowStep(delay=0.2),
+                persistent_batch,
+            ]
+        )
+        controller = flow.run()
+
+        # Emit events (they accumulate in persistent_batch._batch)
+        for i in range(10):
+            await controller.emit({"value": i, "cycle": cycle, "data": "x" * 100})
+
+        # Start drain but cancel before it completes
+        await controller.terminate()
+        await asyncio.sleep(0.05)
+
+        # Cancel mid-drain (simulating Go timeout / overlapping drain)
+        controller._loop_task.cancel()
+        # await_termination() catches CancelledError and calls _clear_resources() automatically
+        await controller.await_termination()
+
+    gc.collect()
+    snapshot_after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+
+    # Count total events in batch (it's a dict of key -> list)
+    batch_size_after = sum(len(v) for v in persistent_batch._batch.values())
+
+    # The batch should not grow unboundedly - it should be cleared on drain
+    # If leaking: batch_size_after = 50 cycles * 10 events = 500 events
+    # If working: batch_size_after should be 0 or small (last cycle's unflushed)
+    max_expected_batch = 20  # Allow some buffered events, but not 500
+    assert batch_size_after <= max_expected_batch, (
+        f"Buffer leak detected: _batch has {batch_size_after} events after {num_cycles} "
+        f"interrupted drain cycles (max expected: {max_expected_batch}). "
+        f"Buffers are not being cleared when drain is cancelled."
+    )
+
+    # Also check memory growth
+    stats = snapshot_after.compare_to(snapshot_before, "lineno")
+    total_growth = sum(stat.size_diff for stat in stats if stat.size_diff > 0)
+
+    max_growth_bytes = 50 * 1024  # 50KB max
+    assert total_growth <= max_growth_bytes, (
+        f"Memory leak detected: {total_growth / 1024:.1f}KB grew after {num_cycles} "
+        f"interrupted drain cycles (max allowed: {max_growth_bytes / 1024:.1f}KB)."
+    )
+
+
+async def test_clear_resources_clears_circular_references():
+    """
+    Test that _clear_resources() properly clears circular references.
+
+    Flow steps have circular references via _outlets/_inlets that prevent
+    garbage collection. _clear_resources() must clear these to enable GC.
+    """
+    from storey import Batch
+
+    # Build a flow with multiple steps
+    source = AsyncEmitSource()
+    map_step = Map(lambda x: x)
+    batch_step = Batch(max_events=100, flush_after_seconds=60)
+    reduce_step = Reduce([], lambda acc, x: acc + [x])
+
+    controller = build_flow([source, map_step, batch_step, reduce_step]).run()
+
+    # Emit some events
+    for i in range(3):
+        await controller.emit({"value": i})
+
+    # Terminate normally
+    await controller.terminate()
+    await controller.await_termination()
+
+    # Verify circular references exist before clearing
+    assert len(source._outlets) > 0, "source should have outlets"
+    assert len(map_step._outlets) > 0, "map_step should have outlets"
+    assert len(batch_step._outlets) > 0, "batch_step should have outlets"
+
+    # Clear resources starting from source (propagates to all downstream steps)
+    source._clear_resources()
+
+    # Verify circular references are cleared in all steps
+    assert source._outlets == [], "source._outlets should be cleared"
+    assert source.context is None, "source.context should be None"
+
+    assert map_step._outlets == [], "map_step._outlets should be cleared"
+    assert map_step.context is None, "map_step.context should be None"
+
+    assert batch_step._outlets == [], "batch_step._outlets should be cleared"
+    assert batch_step._timeout_task is None, "batch_step._timeout_task should be None"
+    assert batch_step._extract_key is None, "batch_step._extract_key should be None"
+    assert len(batch_step._batch) == 0, "batch_step._batch should be empty"
+
+    assert reduce_step._outlets == [], "reduce_step._outlets should be cleared"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
When using AsyncEmitSource with Kafka triggers, the Go runtime may timeout
(rebalanceTimeout) before Python's drain completes. This causes Go to send
a new drain signal while the old drain is still running, leading to memory
leaks from orphaned buffers.

Changes:
- Add _clear_resources() to Flow base class to clear references
  (_outlets, _recovery_step, context) that prevent garbage collection
- Add _clear_resources() to _Batching to clear batch buffers (_batch,
  _batch_events, _timeout_task)
- Add _clear_resources() to AsyncEmitSource to propagate cleanup to
  downstream steps
- Handle CancelledError in await_termination() with on_cancel callback
  to automatically clean up resources on external cancellation
- Fix Table._set_aggregations_attrs() to always call _init_flush_task()
  (bug: _get_lock() pre-populates cache, causing flush task init to be skipped)

Tests:
- Add test_overlapping_drain.py with 6 tests covering cancellation scenarios
- Add test for Table flush task initialization bug

https://iguazio.atlassian.net/browse/ML-11518