### PR TITLE
Fix `ParallelExecution` API breakage

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -2155,7 +2155,15 @@ class ParallelExecution(Flow, _StreamingStepMixin):
                 return None
 
         # Non-streaming path
-        if len(runnables) == 1:
+        # Check if any results are generators (not allowed with multiple runnables)
+        for result in results:
+            if _is_generator(result):
+                raise StreamingError(
+                    "Streaming is not supported when multiple runnables are selected. "
+                    "Streaming runnables must be the only runnable selected for an event."
+                )
+        # Use self.runnables (registered) not runnables (selected) to determine wrapping
+        if len(self.runnables) == 1:
             result: _ParallelExecutionRunnableResult = results[0]
             event.body = result.data if results else None
 
@@ -2164,13 +2172,6 @@ class ParallelExecution(Flow, _StreamingStepMixin):
                 "when": result.timestamp.isoformat(sep=" ", timespec="microseconds"),
             }
         else:
-            # Check if any results are generators (not allowed with multiple runnables)
-            for result in results:
-                if _is_generator(result):
-                    raise StreamingError(
-                        "Streaming is not supported when multiple runnables are selected. "
-                        "Streaming runnables must be the only runnable selected for an event."
-                    )
             event.body = {result.runnable_name: result.data for result in results}
             metadata = {
                 result.runnable_name: {

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5376,6 +5376,50 @@ def test_parallel_execution_with_shared_with_selector():
     }
 
 
+def test_parallel_execution_single_selection_from_multiple_runnables():
+    """When multiple runnables are registered but only one is selected,
+    results should still be wrapped with runnable names (dict format).
+
+    This ensures backward compatibility - the wrapping behavior depends on the number
+    of *registered* runnables, not the number of *selected* runnables.
+    """
+    runnable1 = RunnableNaiveNoOp("model1")
+    runnable2 = RunnableNaiveNoOp("model2")
+
+    runnables = [runnable1, runnable2]
+
+    class SelectiveParallelExecution(ParallelExecution):
+        def select_runnables(self, event):
+            # Select only one runnable based on event body
+            selected = event.body.get("select")
+            return [selected] if selected else None
+
+    parallel_execution = SelectiveParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={
+            "model1": "naive",
+            "model2": "naive",
+        },
+    )
+    reduce = Reduce([], lambda acc, x: acc + [x])
+
+    source = SyncEmitSource()
+    source.to(parallel_execution).to(reduce)
+
+    controller = source.run()
+    # Select only model2 for this event
+    controller.emit({"select": "model2", "value": 42})
+    controller.terminate()
+    termination_result = controller.await_termination()
+
+    # Result should be wrapped with runnable name even though only one was selected
+    # (because multiple runnables are *registered*)
+    # RunnableNaiveNoOp returns 1, so we expect {"model2": 1}
+    result = termination_result[0]
+    assert "model2" in result, f"Expected result wrapped with 'model2' key, got: {result}"
+    assert result == {"model2": 1}
+
+
 def test_enrichment():
     busy_wait_pool = RunnableBusyWait("busy1")
     busy_wait_dedicated = RunnableBusyWait("busy2")


### PR DESCRIPTION
#605 broke mlrun test `serving.test_async_flow.test_model_runner_with_selector`.