### PR TITLE
Support `ParallelExecution` with batch

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -332,7 +332,9 @@ class Flow:
         sub_event_copies = []
         if is_batched:
             for sub_event in event.body:
-                sub_event_copies.append(self._deepcopy_event(sub_event, sub_event, False, False))
+                sub_event_copies.append(
+                    self._deepcopy_event(sub_event, sub_event, is_stream_completion=False, is_batched=False)
+                )
                 sub_event._awaitable_result = None
                 sub_event._original_events = None
         event_copy = copy.deepcopy(event)
@@ -387,7 +389,9 @@ class Flow:
             )
 
             for i in range(1, len(outlets)):
-                event_copy = self._deepcopy_event(event, target_obj, is_stream_completion, is_batched)
+                event_copy = self._deepcopy_event(
+                    event, target_obj, is_stream_completion=is_stream_completion, is_batched=is_batched
+                )
                 tasks.append(asyncio.get_running_loop().create_task(outlets[i]._do_and_recover(event_copy)))
         if self.verbose and self.logger:
             step_name = self.name
@@ -2219,7 +2223,9 @@ class ParallelExecution(Flow, _StreamingStepMixin):
             event_bodies = []
             for sub_event in event.body:
                 # copy sub events for avoiding overriding original sub events
-                sub_event_copy = self._deepcopy_event(sub_event, sub_event, False, False)
+                sub_event_copy = self._deepcopy_event(
+                    sub_event, sub_event, is_stream_completion=False, is_batched=False
+                )
                 sub_events_to_modify.append(sub_event_copy)
                 # for the invocation, we only want to pass the body
                 event_bodies.append(copy.deepcopy(sub_event.body))
@@ -2304,7 +2310,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
 
         if is_full_event_batched:
             for sub_event in event.body:
-                self.set_event_metadata(sub_event, metadata)
+                self.set_event_metadata(sub_event, copy.deepcopy(metadata))
         self.set_event_metadata(event, metadata)
         return await self._do_downstream(event)
 

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -2193,7 +2193,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
                 )
             runnables_encountered.add(id(runnable))
             futures.append(future)
-        results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(*futures)
+        results = await asyncio.gather(*futures)
         # Check for streaming response (only when a single runnable is selected)
         if len(runnables) == 1 and results:
             result = results[0]

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -319,6 +319,9 @@ class Flow:
                            (either the event itself or event.original_event for StreamCompletion).
         :param is_stream_completion: If True, copy target is event_copy.original_event,
                                      otherwise it's event_copy itself.
+        :param is_batched: If True, performs nested copying for batched events where event.body contains
+                          a list of sub-events. Only 1 layer of batching is supported. Not supported with
+                          StreamCompletion events.
 
         :returns: The deepcopied event with unpicklable attributes restored.
         """

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -347,7 +347,7 @@ class Flow:
         target_obj._original_events = original_events
         if is_batched:
             event_copy.body = sub_event_copies
-            for sub_event, sub_event_copy in zip(event, sub_event_copies):
+            for sub_event, sub_event_copy in zip(event.body, sub_event_copies):
                 sub_event._awaitable_result = sub_event_copy._awaitable_result
                 sub_event._original_events = sub_event_copy._original_events
         return event_copy

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -2208,18 +2208,18 @@ class ParallelExecution(Flow, _StreamingStepMixin):
                 await self._emit_streaming_chunks(event, result)
                 return None
 
-            # Non-streaming path
-            # Check if any results are generators (not allowed with multiple runnables)
+        # Non-streaming path
+        # Check if any results are generators (not allowed with multiple runnables)
         for result in results:
             if _is_generator(result):
                 raise StreamingError(
                     "Streaming is not supported when multiple runnables are selected. "
                     "Streaming runnables must be the only runnable selected for an event."
                 )
-            # If no runnables were selected, don't emit the event
+        # If no runnables were selected, don't emit the event
         if not results:
             return None
-            # Use self.runnables (registered) not runnables (selected) to determine wrapping
+        # Use self.runnables (registered) not runnables (selected) to determine wrapping
         if len(self.runnables) == 1:
             result: _ParallelExecutionRunnableResult = results[0]
             event.body = result.data

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -87,6 +87,15 @@ class Flow:
         if self._method_is_overridden("select_outlets", Flow) and self._create_name_to_outlet:
             self._init_name_to_outlet()
 
+    @staticmethod
+    def _prepare_event_for_deepcopy(event):
+        # Temporarily delete self-reference to avoid deepcopy getting stuck in an infinite loop
+        awaitable_result = event._awaitable_result
+        event._awaitable_result = None
+        original_events = getattr(event, "_original_events", None)
+        event._original_events = None
+        return awaitable_result, original_events
+
     def _init_name_to_outlet(self):
         for outlet in self._outlets:
             if outlet.name in self._name_to_outlet:
@@ -311,19 +320,44 @@ class Flow:
         # If there is more than one outlet, allow concurrent execution.
         tasks = []
         if len(outlets) > 1:
-            awaitable_result = event._awaitable_result
-            event._awaitable_result = None
-            original_events = getattr(event, "_original_events", None)
-            # Temporarily delete self-reference to avoid deepcopy getting stuck in an infinite loop
-            event._original_events = None
-            for i in range(1, len(outlets)):
+            awaitable_result, original_events = self._prepare_event_for_deepcopy(event)
+
+            # Check if event body is a list of Event/MockEvent
+            is_batched = (
+                    isinstance(event.body, list) and
+                    event.body and
+                    all(sub_event.__class__.__name__ in ("MockEvent", "Event") for sub_event in event.body)
+            )
+
+            if is_batched:
+                # Prepare deepcopy info for each sub-event
+                sub_event_thread_lock_values = [
+                    self._prepare_event_for_deepcopy(sub_event) for sub_event in event.body
+                ]
+
+            # Create tasks for outlets[1:]
+            for outlet in outlets[1:]:
                 event_copy = copy.deepcopy(event)
                 event_copy._awaitable_result = awaitable_result
                 event_copy._original_events = original_events
-                tasks.append(asyncio.get_running_loop().create_task(outlets[i]._do_and_recover(event_copy)))
-            # Set self-reference back after deepcopy
-            event._original_events = original_events
+
+                if is_batched:
+                    for sub_event_copy, (sub_awaitable, sub_original) in zip(event_copy.body,
+                                                                             sub_event_thread_lock_values):
+                        sub_event_copy._awaitable_result = sub_awaitable
+                        sub_event_copy._original_events = sub_original
+
+                tasks.append(asyncio.get_running_loop().create_task(outlet._do_and_recover(event_copy)))
+
+            # Attach self references to original event
             event._awaitable_result = awaitable_result
+            event._original_events = original_events
+
+            if is_batched:
+                for sub_event, (sub_awaitable, sub_original) in zip(event.body, sub_event_thread_lock_values):
+                    sub_event._awaitable_result = sub_awaitable
+                    sub_event._original_events = sub_original
+
         if self.verbose and self.logger:
             step_name = self.name
             event_string = self._event_string(event)
@@ -1919,6 +1953,13 @@ class ParallelExecution(Flow):
         self.max_threads = max_threads or 32
         self.pool_factor = pool_factor or 1
 
+    @staticmethod
+    def set_event_metadata(event, metadata: dict):
+        if hasattr(event, "_metadata") and isinstance(event._metadata, dict):
+            event._metadata.update(metadata)
+        else:
+            event._metadata = metadata
+
     def select_runnables(self, event) -> Optional[Union[list[str], list[ParallelExecutionRunnable]]]:
         """
         Given an event, returns a list of runnables (or a list of runnable names) to execute on it. It can also return
@@ -1957,6 +1998,21 @@ class ParallelExecution(Flow):
             return await self._do_downstream(_termination_obj)
         else:
             event = self.preprocess_event(event)
+            is_full_event_batched = (
+                all(sub_event.__class__.__name__ in ("MockEvent", "Event") for sub_event in event.body))
+            if is_full_event_batched:
+                original_sub_events = []
+                event_bodies = []
+                for sub_event in event.body:
+                    awaitable_result, original_events = self._prepare_event_for_deepcopy(sub_event)
+                    sub_event_copy = copy.deepcopy(sub_event)
+                    sub_event_copy._awaitable_result = awaitable_result
+                    sub_event_copy._original_events = original_events
+                    original_sub_events.append(sub_event_copy)
+                    # for the invocation, we only want to pass the body
+                    event_bodies.append(copy.deepcopy(sub_event.body))
+            event.body = event_bodies
+
             runnables = self.select_runnables(event)
             if runnables is None:
                 runnables = self.runnables
@@ -1987,14 +2043,19 @@ class ParallelExecution(Flow):
                 futures.append(future)
             results: list[_ParallelExecutionRunnableResult] = await asyncio.gather(*futures)
             if len(self.runnables) == 1:
-                event.body = results[0].data if results else None
-
                 metadata = {
                     "microsec": results[0].runtime,
                     "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
                 }
+                # TODO: batching support
+                if is_full_event_batched:
+                    # reconstruct the full event batch
+                    for i, sub_event in enumerate(original_sub_events):
+                        sub_event.body = results[0].data[i] if results else None
+                    event.body = original_sub_events
+                else:
+                    event.body = results[0].data if results else None
             else:
-                event.body = {result.runnable_name: result.data for result in results}
                 metadata = {
                     result.runnable_name: {
                         "microsec": result.runtime,
@@ -2002,11 +2063,17 @@ class ParallelExecution(Flow):
                     }
                     for result in results
                 }
-
-            if hasattr(event, "_metadata") and isinstance(event._metadata, dict):
-                event._metadata.update(metadata)
-            else:
-                event._metadata = metadata
+                if is_full_event_batched:
+                    for i, sub_event in enumerate(original_sub_events):
+                        sub_event.body = {result.runnable_name:
+                                              result.data[i] for result in results}
+                    event.body = original_sub_events
+                else:
+                    event.body = {result.runnable_name: result.data for result in results}
+            if is_full_event_batched:
+                for sub_event in event.body:
+                    self.set_event_metadata(sub_event, metadata)
+            self.set_event_metadata(event, metadata)
             return await self._do_downstream(event)
 
     def _verify_runnables(self, runnables: List[Union[str, ParallelExecutionRunnable]]):

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -324,16 +324,14 @@ class Flow:
 
             # Check if event body is a list of Event/MockEvent
             is_batched = (
-                    isinstance(event.body, list) and
-                    event.body and
-                    all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
+                isinstance(event.body, list)
+                and event.body
+                and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
             )
 
             if is_batched:
                 # Prepare deepcopy info for each sub-event
-                sub_event_thread_lock_values = [
-                    self._prepare_event_for_deepcopy(sub_event) for sub_event in event.body
-                ]
+                sub_event_thread_lock_values = [self._prepare_event_for_deepcopy(sub_event) for sub_event in event.body]
 
             # Create tasks for outlets[1:]
             for outlet in outlets[1:]:
@@ -342,8 +340,9 @@ class Flow:
                 event_copy._original_events = original_events
 
                 if is_batched:
-                    for sub_event_copy, (sub_awaitable, sub_original) in zip(event_copy.body,
-                                                                             sub_event_thread_lock_values):
+                    for sub_event_copy, (sub_awaitable, sub_original) in zip(
+                        event_copy.body, sub_event_thread_lock_values
+                    ):
                         sub_event_copy._awaitable_result = sub_awaitable
                         sub_event_copy._original_events = sub_original
 
@@ -2000,7 +1999,10 @@ class ParallelExecution(Flow):
             event = self.preprocess_event(event)
             original_sub_events = []
             is_full_event_batched = (
-                all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body))
+                isinstance(event.body, list)
+                and event.body
+                and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
+            )
             if is_full_event_batched:
                 event_bodies = []
                 for sub_event in event.body:
@@ -2064,8 +2066,7 @@ class ParallelExecution(Flow):
                 }
                 if is_full_event_batched:
                     for i, sub_event in enumerate(original_sub_events):
-                        sub_event.body = {result.runnable_name:
-                                              result.data[i] for result in results}
+                        sub_event.body = {result.runnable_name: result.data[i] for result in results}
                     event.body = original_sub_events
                 else:
                     event.body = {result.runnable_name: result.data for result in results}

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -2011,7 +2011,7 @@ class ParallelExecution(Flow):
                     original_sub_events.append(sub_event_copy)
                     # for the invocation, we only want to pass the body
                     event_bodies.append(copy.deepcopy(sub_event.body))
-            event.body = event_bodies
+                event.body = event_bodies
 
             runnables = self.select_runnables(event)
             if runnables is None:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -333,8 +333,6 @@ class Flow:
         sub_event_copies = []
         if is_batched:
             for sub_event in event.body:
-                if isinstance(sub_event, StreamCompletion):
-                    raise ValueError("batching is not supported with streaming")
                 sub_event_copies.append(self._deepcopy_event(sub_event, sub_event, False, False))
                 sub_event._awaitable_result = None
                 sub_event._original_events = None
@@ -386,7 +384,7 @@ class Flow:
                 not is_stream_completion
                 and isinstance(getattr(event, "body", None), list)
                 and event.body
-                and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
+                and all(hasattr(sub_event, "body") for sub_event in event.body)
             )
 
             for i in range(1, len(outlets)):
@@ -2154,14 +2152,12 @@ class ParallelExecution(Flow, _StreamingStepMixin):
             not isinstance(event, StreamCompletion)
             and isinstance(getattr(event, "body", None), list)
             and event.body
-            and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
+            and all(hasattr(sub_event, "body") for sub_event in event.body)
         )
         if is_full_event_batched:
             event_bodies = []
             for sub_event in event.body:
                 # copy sub events for avoiding overriding original sub events
-                if isinstance(sub_event, StreamCompletion):
-                    raise ValueError("batching is not supported with streaming")
                 sub_event_copy = self._deepcopy_event(sub_event, sub_event, False, False)
                 sub_events_to_modify.append(sub_event_copy)
                 # for the invocation, we only want to pass the body

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -383,12 +383,11 @@ class Flow:
             is_stream_completion = isinstance(event, StreamCompletion)
             target_obj = event.original_event if is_stream_completion else event
             is_batched = (
-                isinstance(event.body, list)
+                not is_stream_completion
+                and isinstance(getattr(event, "body", None), list)
                 and event.body
                 and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
             )
-            if is_batched and is_stream_completion:
-                raise ValueError("batching is not supported with streaming")
 
             for i in range(1, len(outlets)):
                 event_copy = self._deepcopy_event(event, target_obj, is_stream_completion, is_batched)
@@ -2152,7 +2151,8 @@ class ParallelExecution(Flow, _StreamingStepMixin):
         event = self.preprocess_event(event)
         sub_events_to_modify = []
         is_full_event_batched = (
-            isinstance(event.body, list)
+            not isinstance(event, StreamCompletion)
+            and isinstance(getattr(event, "body", None), list)
             and event.body
             and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
         )

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -387,9 +387,8 @@ class Flow:
                 and event.body
                 and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
             )
-            if is_batched:
-                if is_stream_completion:
-                    raise ValueError("batching is not supported with streaming")
+            if is_batched and is_stream_completion:
+                raise ValueError("batching is not supported with streaming")
 
             for i in range(1, len(outlets)):
                 event_copy = self._deepcopy_event(event, target_obj, is_stream_completion, is_batched)

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -67,7 +67,7 @@ def is_batched_event(event) -> bool:
         not isinstance(event, StreamCompletion)
         and isinstance(getattr(event, "body", None), list)
         and event.body
-        and all(hasattr(sub_event, "body") for sub_event in event.body)
+        and any(hasattr(sub_event, "body") for sub_event in event.body)
     )
 
 

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -62,6 +62,15 @@ def _is_generator(obj) -> bool:
     return inspect.isgenerator(obj) or inspect.isasyncgen(obj)
 
 
+def is_batched_event(event) -> bool:
+    return (
+        not isinstance(event, StreamCompletion)
+        and isinstance(getattr(event, "body", None), list)
+        and event.body
+        and all(hasattr(sub_event, "body") for sub_event in event.body)
+    )
+
+
 class Flow:
     _legal_first_step = False
 
@@ -381,16 +390,10 @@ class Flow:
             # Deep copy event and create a task per outlet (except the first, which is awaited directly below)
             is_stream_completion = isinstance(event, StreamCompletion)
             target_obj = event.original_event if is_stream_completion else event
-            is_batched = (
-                not is_stream_completion
-                and isinstance(getattr(event, "body", None), list)
-                and event.body
-                and all(hasattr(sub_event, "body") for sub_event in event.body)
-            )
 
             for i in range(1, len(outlets)):
                 event_copy = self._deepcopy_event(
-                    event, target_obj, is_stream_completion=is_stream_completion, is_batched=is_batched
+                    event, target_obj, is_stream_completion=is_stream_completion, is_batched=is_batched_event(event)
                 )
                 tasks.append(asyncio.get_running_loop().create_task(outlets[i]._do_and_recover(event_copy)))
         if self.verbose and self.logger:
@@ -2213,12 +2216,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
 
         event = self.preprocess_event(event)
         sub_events_to_modify = []
-        is_full_event_batched = (
-            not isinstance(event, StreamCompletion)
-            and isinstance(getattr(event, "body", None), list)
-            and event.body
-            and all(hasattr(sub_event, "body") for sub_event in event.body)
-        )
+        is_full_event_batched = is_batched_event(event)
         if is_full_event_batched:
             event_bodies = []
             for sub_event in event.body:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -320,8 +320,7 @@ class Flow:
         :param is_stream_completion: If True, copy target is event_copy.original_event,
                                      otherwise it's event_copy itself.
         :param is_batched: If True, performs nested copying for batched events where event.body contains
-                          a list of sub-events. Only 1 layer of batching is supported. Not supported with
-                          StreamCompletion events.
+                          a list of sub-events. Only 1 layer of batching is supported.
 
         :returns: The deepcopied event with unpicklable attributes restored.
         """

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -2148,6 +2148,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
         # Forward termination object and StreamCompletion without processing
         if event is _termination_obj or isinstance(event, StreamCompletion):
             return await self._do_downstream(event)
+
         event = self.preprocess_event(event)
         sub_events_to_modify = []
         is_full_event_batched = (
@@ -2193,6 +2194,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
             runnables_encountered.add(id(runnable))
             futures.append(future)
         results = await asyncio.gather(*futures)
+
         # Check for streaming response (only when a single runnable is selected)
         if len(runnables) == 1 and results:
             result = results[0]
@@ -2212,6 +2214,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
         # If no runnables were selected, don't emit the event
         if not results:
             return None
+
         # Use self.runnables (registered) not runnables (selected) to determine wrapping
         if len(self.runnables) == 1:
             result: _ParallelExecutionRunnableResult = results[0]

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -326,7 +326,7 @@ class Flow:
             is_batched = (
                     isinstance(event.body, list) and
                     event.body and
-                    all(sub_event.__class__.__name__ in ("MockEvent", "Event") for sub_event in event.body)
+                    all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
             )
 
             if is_batched:
@@ -1998,10 +1998,10 @@ class ParallelExecution(Flow):
             return await self._do_downstream(_termination_obj)
         else:
             event = self.preprocess_event(event)
+            original_sub_events = []
             is_full_event_batched = (
-                all(sub_event.__class__.__name__ in ("MockEvent", "Event") for sub_event in event.body))
+                all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body))
             if is_full_event_batched:
-                original_sub_events = []
                 event_bodies = []
                 for sub_event in event.body:
                     awaitable_result, original_events = self._prepare_event_for_deepcopy(sub_event)
@@ -2047,7 +2047,6 @@ class ParallelExecution(Flow):
                     "microsec": results[0].runtime,
                     "when": results[0].timestamp.isoformat(sep=" ", timespec="microseconds"),
                 }
-                # TODO: batching support
                 if is_full_event_batched:
                     # reconstruct the full event batch
                     for i, sub_event in enumerate(original_sub_events):

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -113,15 +113,6 @@ class Flow:
         if self._method_is_overridden("select_outlets", Flow) and self._create_name_to_outlet:
             self._init_name_to_outlet()
 
-    @staticmethod
-    def _prepare_event_for_deepcopy(event):
-        # Temporarily delete self-reference to avoid deepcopy getting stuck in an infinite loop
-        awaitable_result = event._awaitable_result
-        event._awaitable_result = None
-        original_events = getattr(event, "_original_events", None)
-        event._original_events = None
-        return awaitable_result, original_events
-
     def _init_name_to_outlet(self):
         for outlet in self._outlets:
             if outlet.name in self._name_to_outlet:
@@ -320,7 +311,7 @@ class Flow:
     def _should_terminate(self):
         return self._termination_received == len(self._inlets)
 
-    def _deepcopy_event_for_outlet(self, event, target_obj, is_stream_completion: bool, is_batched=False):
+    def _deepcopy_event(self, event, target_obj, is_stream_completion: bool, is_batched=False):
         """Deepcopy event while handling unpicklable attributes on target_obj.
 
         :param event: The event to deepcopy.
@@ -341,7 +332,7 @@ class Flow:
             for sub_event in event.body:
                 if isinstance(sub_event, StreamCompletion):
                     raise ValueError("batching is not supported with streaming")
-                sub_event_copies.append(self._deepcopy_event_for_outlet(sub_event, sub_event, False, False))
+                sub_event_copies.append(self._deepcopy_event(sub_event, sub_event, False, False))
                 sub_event._awaitable_result = None
                 sub_event._original_events = None
         event_copy = copy.deepcopy(event)
@@ -398,7 +389,7 @@ class Flow:
                     raise ValueError("batching is not supported with streaming")
 
             for i in range(1, len(outlets)):
-                event_copy = self._deepcopy_event_for_outlet(event, target_obj, is_stream_completion)
+                event_copy = self._deepcopy_event(event, target_obj, is_stream_completion)
                 tasks.append(asyncio.get_running_loop().create_task(outlets[i]._do_and_recover(event_copy)))
         if self.verbose and self.logger:
             step_name = self.name
@@ -2156,7 +2147,7 @@ class ParallelExecution(Flow, _StreamingStepMixin):
         if event is _termination_obj or isinstance(event, StreamCompletion):
             return await self._do_downstream(event)
         event = self.preprocess_event(event)
-        original_sub_events = []
+        sub_events_to_modify = []
         is_full_event_batched = (
             isinstance(event.body, list)
             and event.body
@@ -2165,11 +2156,11 @@ class ParallelExecution(Flow, _StreamingStepMixin):
         if is_full_event_batched:
             event_bodies = []
             for sub_event in event.body:
-                awaitable_result, original_events = self._prepare_event_for_deepcopy(sub_event)
-                sub_event_copy = copy.deepcopy(sub_event)
-                sub_event_copy._awaitable_result = awaitable_result
-                sub_event_copy._original_events = original_events
-                original_sub_events.append(sub_event_copy)
+                # copy sub events for avoiding overriding original sub events
+                if isinstance(sub_event, StreamCompletion):
+                    raise ValueError("batching is not supported with streaming")
+                sub_event_copy = self._deepcopy_event(sub_event, sub_event, False, False)
+                sub_events_to_modify.append(sub_event_copy)
                 # for the invocation, we only want to pass the body
                 event_bodies.append(copy.deepcopy(sub_event.body))
             event.body = event_bodies
@@ -2229,9 +2220,9 @@ class ParallelExecution(Flow, _StreamingStepMixin):
             }
             if is_full_event_batched:
                 # reconstruct the full event batch
-                for i, sub_event in enumerate(original_sub_events):
+                for i, sub_event in enumerate(sub_events_to_modify):
                     sub_event.body = result.data[i]
-                event.body = original_sub_events
+                event.body = sub_events_to_modify
             else:
                 event.body = result.data
         else:
@@ -2243,9 +2234,9 @@ class ParallelExecution(Flow, _StreamingStepMixin):
                 for result in results
             }
             if is_full_event_batched:
-                for i, sub_event in enumerate(original_sub_events):
+                for i, sub_event in enumerate(sub_events_to_modify):
                     sub_event.body = {result.runnable_name: result.data[i] for result in results}
-                event.body = original_sub_events
+                event.body = sub_events_to_modify
             else:
                 event.body = {result.runnable_name: result.data for result in results}
 

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -392,7 +392,7 @@ class Flow:
                     raise ValueError("batching is not supported with streaming")
 
             for i in range(1, len(outlets)):
-                event_copy = self._deepcopy_event(event, target_obj, is_stream_completion)
+                event_copy = self._deepcopy_event(event, target_obj, is_stream_completion, is_batched)
                 tasks.append(asyncio.get_running_loop().create_task(outlets[i]._do_and_recover(event_copy)))
         if self.verbose and self.logger:
             step_name = self.name

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -320,7 +320,7 @@ class Flow:
     def _should_terminate(self):
         return self._termination_received == len(self._inlets)
 
-    def _deepcopy_event_for_outlet(self, event, target_obj, is_stream_completion: bool, is_batched = False):
+    def _deepcopy_event_for_outlet(self, event, target_obj, is_stream_completion: bool, is_batched=False):
         """Deepcopy event while handling unpicklable attributes on target_obj.
 
         :param event: The event to deepcopy.
@@ -341,7 +341,7 @@ class Flow:
             for sub_event in event.body:
                 if isinstance(sub_event, StreamCompletion):
                     raise ValueError("batching is not supported with streaming")
-                sub_event_copies.append(self._deepcopy_event_for_outlet(sub_event,sub_event, False,False))
+                sub_event_copies.append(self._deepcopy_event_for_outlet(sub_event, sub_event, False, False))
                 sub_event._awaitable_result = None
                 sub_event._original_events = None
         event_copy = copy.deepcopy(event)
@@ -389,14 +389,13 @@ class Flow:
             is_stream_completion = isinstance(event, StreamCompletion)
             target_obj = event.original_event if is_stream_completion else event
             is_batched = (
-                    isinstance(event.body, list)
-                    and event.body
-                    and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
+                isinstance(event.body, list)
+                and event.body
+                and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
             )
             if is_batched:
                 if is_stream_completion:
                     raise ValueError("batching is not supported with streaming")
-
 
             for i in range(1, len(outlets)):
                 event_copy = self._deepcopy_event_for_outlet(event, target_obj, is_stream_completion)
@@ -2154,14 +2153,14 @@ class ParallelExecution(Flow, _StreamingStepMixin):
 
     async def _do(self, event):
         # Forward termination object and StreamCompletion without processing
-        if event is _termination_obj:
-            return await self._do_downstream(_termination_obj)
+        if event is _termination_obj or isinstance(event, StreamCompletion):
+            return await self._do_downstream(event)
         event = self.preprocess_event(event)
         original_sub_events = []
         is_full_event_batched = (
-                isinstance(event.body, list)
-                and event.body
-                and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
+            isinstance(event.body, list)
+            and event.body
+            and all("event" in sub_event.__class__.__name__.lower() for sub_event in event.body)
         )
         if is_full_event_batched:
             event_bodies = []

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2392,16 +2392,10 @@ def test_basic_batch_with_parallel_execution():
             "now": "naive",
         },
     )
-    flat_map1 = FlatMap(fn=lambda x: x.body, full_event=True)
-
-    collector = Collector(expected_completions=2)
+    flat_map = FlatMap(fn=lambda x: x.body, full_event=True)
     reducer = Reduce([], lambda acc, x: append_and_return(acc, x))
-
     source.to(batch_step).to(parallel_execution)
-    parallel_execution.to(flat_map1).to(collector)
-
-    collector.to(reducer)
-
+    parallel_execution.to(flat_map).to(reducer)
     controller = source.run()
 
     for i in range(number_of_events):
@@ -2417,6 +2411,73 @@ def test_basic_batch_with_parallel_execution():
     for i in range(number_of_events):
         expected_add = 10 + i
         expected_multiply = i * 2
+        assert termination_result[i]["add"] == expected_add
+        assert termination_result[i]["multiply"] == expected_multiply
+        batch_number = math.floor(i / batch_size)
+        if previous_batch_number == -1 or batch_number != previous_batch_number:
+            expected_timestamp = termination_result[i]["now"]
+        else:
+            assert termination_result[i]["now"] == expected_timestamp
+        previous_batch_number = batch_number
+
+
+def test_batch_with_parallel_execution_split():
+    """Test batched ParallelExecution with splitting to multiple outlets (len(outlets) > 1 path)."""
+    batch_size = 3
+    number_of_events = 10
+
+    runnables = [
+        RunnableMultiplyBy2("multiply"),
+        RunnableAdd10("add"),
+        RunnableGetNow("now"),
+    ]
+
+    source = SyncEmitSource()
+    batch_step = Batch(batch_size, 100, full_event=True)
+    parallel_execution = MyParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={
+            "multiply": "naive",
+            "add": "naive",
+            "now": "naive",
+        },
+    )
+
+    flat_map1 = FlatMap(fn=lambda x: x.body, full_event=True)
+    flat_map2 = FlatMap(fn=lambda x: x.body, full_event=True)
+    collector = Collector(expected_completions=2)
+    reducer = Reduce([], lambda acc, x: append_and_return(acc, x))
+
+    source.to(batch_step).to(parallel_execution)
+    parallel_execution.to(flat_map1).to(collector)
+    parallel_execution.to(flat_map2).to(collector)
+    collector.to(reducer)
+
+    controller = source.run()
+
+    for i in range(number_of_events):
+        sleep(0.2)
+        controller.emit(i)
+
+    controller.terminate()
+    termination_result = controller.await_termination()
+
+    # The final result should contain a duplicated value since the flow is split into two branches
+    expected_number_of_events = number_of_events * 2
+    assert len(termination_result) == expected_number_of_events
+
+    # Sort by timestamp and then by value to ensure correct order after split
+    termination_result = sorted(termination_result, key=lambda x: (x["now"], x["add"]))
+
+    previous_batch_number = -1
+    expected_timestamp = datetime.min
+    # because of the split, the batch size of the results is doubled
+    batch_size = batch_size * 2
+    for i in range(expected_number_of_events):
+        # because of the split, we expect alternating add/multiply values every two items
+        fixed_index = math.floor(i / 2)
+        expected_add = 10 + fixed_index
+        expected_multiply = fixed_index * 2
         assert termination_result[i]["add"] == expected_add
         assert termination_result[i]["multiply"] == expected_multiply
         batch_number = math.floor(i / batch_size)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2358,7 +2358,7 @@ def test_batch_with_parallel_execution():
                 return [sub_value + 10 for sub_value in data]
             return data + 10
 
-    class RunnableGetTime(ParallelExecutionRunnable):
+    class RunnableGetNow(ParallelExecutionRunnable):
         def init(self):
             pass
 
@@ -2371,7 +2371,7 @@ def test_batch_with_parallel_execution():
     runnables = [
         RunnableMultiplyBy2("multiply"),
         RunnableAdd10("add"),
-        RunnableGetTime("now"),
+        RunnableGetNow("now"),
     ]
 
     class MyParallelExecution(ParallelExecution):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4016,6 +4016,9 @@ async def async_test_async_metadata_fields():
     assert result.key == "k1"
     assert result.body == body
 
+def test_async_metadata_fields():
+    asyncio.run(async_test_async_metadata_fields())
+
 
 def test_uuid():
     def copy_and_set_body(event):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -123,20 +123,20 @@ class RunnableAdd10(ParallelExecutionRunnable):
         return data + 10
 
 
-class RunnableGetNow(ParallelExecutionRunnable):
+class RunnableGetRandom(ParallelExecutionRunnable):
     def init(self):
         pass
 
     def run(self, data, path, origin_name=None):
-        now = datetime.now(timezone.utc)
+        random_uuid = str(uuid.uuid4())
         if isinstance(data, list):
-            return [now] * len(data)
-        return now
+            return [random_uuid] * len(data)
+        return random_uuid
 
 
 class MyParallelExecution(ParallelExecution):
     def select_runnables(self, event):
-        return ["multiply", "add", "now"]
+        return ["multiply", "add", "uuid"]
 
 
 def test_functional_flow():
@@ -2380,20 +2380,20 @@ def test_basic_batch_with_parallel_execution():
     runnables = [
         RunnableMultiplyBy2("multiply"),
         RunnableAdd10("add"),
-        RunnableGetNow("now"),
+        RunnableGetRandom("uuid"),
     ]
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
             "multiply": "naive",
             "add": "naive",
-            "now": "naive",
+            "uuid": "naive",
         },
     )
     controller = build_flow(
         [
             SyncEmitSource(),
-            Batch(max_events=batch_size, flush_after_seconds=100, full_event=True),
+            Batch(max_events=batch_size, flush_after_seconds=4, full_event=True),
             parallel_execution,
             FlatMap(fn=lambda x: x.body, full_event=True),
             Reduce(initial_value=[], fn=lambda acc, x: append_and_return(acc, x)),
@@ -2409,7 +2409,7 @@ def test_basic_batch_with_parallel_execution():
     assert len(termination_result) == number_of_events
 
     previous_batch_number = -1
-    expected_timestamp = datetime.min
+    expected_uuid = ""
     for i in range(number_of_events):
         expected_add = 10 + i
         expected_multiply = i * 2
@@ -2417,9 +2417,9 @@ def test_basic_batch_with_parallel_execution():
         assert termination_result[i]["multiply"] == expected_multiply
         batch_number = math.floor(i / batch_size)
         if previous_batch_number == -1 or batch_number != previous_batch_number:
-            expected_timestamp = termination_result[i]["now"]
+            expected_uuid = termination_result[i]["uuid"]
         else:
-            assert termination_result[i]["now"] == expected_timestamp
+            assert termination_result[i]["uuid"] == expected_uuid
         previous_batch_number = batch_number
 
 
@@ -2431,17 +2431,17 @@ def test_batch_with_parallel_execution_split():
     runnables = [
         RunnableMultiplyBy2("multiply"),
         RunnableAdd10("add"),
-        RunnableGetNow("now"),
+        RunnableGetRandom("uuid"),
     ]
 
     source = SyncEmitSource()
-    batch_step = Batch(batch_size, 100, full_event=True)
+    batch_step = Batch(max_events=batch_size, flush_after_seconds=4, full_event=True)
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
             "multiply": "naive",
             "add": "naive",
-            "now": "naive",
+            "uuid": "naive",
         },
     )
 
@@ -2468,11 +2468,11 @@ def test_batch_with_parallel_execution_split():
     expected_number_of_events = number_of_events * 2
     assert len(termination_result) == expected_number_of_events
 
-    # Sort by timestamp and then by value to ensure correct order after split
-    termination_result = sorted(termination_result, key=lambda x: (x["now"], x["add"]))
+    # Sort by value to ensure correct order after split
+    termination_result = sorted(termination_result, key=lambda x: (x["add"]))
 
     previous_batch_number = -1
-    expected_timestamp = datetime.min
+    expected_uuid = ""
     # because of the split, the batch size of the results is doubled
     batch_size = batch_size * 2
     for i in range(expected_number_of_events):
@@ -2484,9 +2484,9 @@ def test_batch_with_parallel_execution_split():
         assert termination_result[i]["multiply"] == expected_multiply
         batch_number = math.floor(i / batch_size)
         if previous_batch_number == -1 or batch_number != previous_batch_number:
-            expected_timestamp = termination_result[i]["now"]
+            expected_uuid = termination_result[i]["uuid"]
         else:
-            assert termination_result[i]["now"] == expected_timestamp
+            assert termination_result[i]["uuid"] == expected_uuid
         previous_batch_number = batch_number
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -22,8 +22,9 @@ import tempfile
 import time
 import traceback
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from random import choice
+from time import sleep
 from unittest.mock import MagicMock
 
 import fakeredis
@@ -2336,6 +2337,8 @@ def test_batch_with_timeout():
 
 def test_batch_with_parallel_execution():
     """Test that Batch step with full_event=True works correctly with ParallelExecution."""
+    batch_size = 3
+    number_of_events = 10
 
     class RunnableMultiplyBy2(ParallelExecutionRunnable):
         def init(self):
@@ -2355,51 +2358,66 @@ def test_batch_with_parallel_execution():
                 return [sub_value + 10 for sub_value in data]
             return data + 10
 
+    class RunnableGetTime(ParallelExecutionRunnable):
+        def init(self):
+            pass
+
+        def run(self, data, path, origin_name=None):
+            now = datetime.now(timezone.utc)
+            if isinstance(data, list):
+                return [now] * len(data)
+            return now
+
     runnables = [
         RunnableMultiplyBy2("multiply"),
         RunnableAdd10("add"),
+        RunnableGetTime("now"),
     ]
 
     class MyParallelExecution(ParallelExecution):
         def select_runnables(self, event):
-            return ["multiply", "add"]
+            return ["multiply", "add", "now"]
 
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
             "multiply": "naive",
             "add": "naive",
+            "now": "naive",
         },
     )
 
     controller = build_flow(
         [
             SyncEmitSource(),
-            Batch(3, 100, full_event=True),
+            Batch(batch_size, 100, full_event=True),
             parallel_execution,
             FlatMap(fn=lambda x: x.body, full_event=True),
             Reduce([], lambda acc, x: append_and_return(acc, x)),
         ]
     ).run()
 
-    # Emit 10 events
-    for i in range(10):
+    for i in range(number_of_events):
+        sleep(0.2)
         controller.emit(i)
 
     controller.terminate()
     termination_result = controller.await_termination()
+    assert len(termination_result) == number_of_events
 
-    assert len(termination_result) == 10
-    assert termination_result[0] == {"multiply": 0, "add": 10}
-    assert termination_result[1] == {"multiply": 2, "add": 11}
-    assert termination_result[2] == {"multiply": 4, "add": 12}
-    assert termination_result[3] == {"multiply": 6, "add": 13}
-    assert termination_result[4] == {"multiply": 8, "add": 14}
-    assert termination_result[5] == {"multiply": 10, "add": 15}
-    assert termination_result[6] == {"multiply": 12, "add": 16}
-    assert termination_result[7] == {"multiply": 14, "add": 17}
-    assert termination_result[8] == {"multiply": 16, "add": 18}
-    assert termination_result[9] == {"multiply": 18, "add": 19}
+    previous_batch_number = -1
+    expected_timestamp = datetime.min
+    for i in range(number_of_events):
+        expected_add = 10 + i
+        expected_multiply = i * 2
+        assert termination_result[i]["add"] == expected_add
+        assert termination_result[i]["multiply"] == expected_multiply
+        batch_number = math.floor(i / batch_size)
+        if previous_batch_number == -1 or batch_number != previous_batch_number:
+            expected_timestamp = termination_result[i]["now"]
+        else:
+            assert termination_result[i]["now"] == expected_timestamp
+        previous_batch_number = batch_number
 
 
 async def async_test_write_csv(tmpdir):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -118,8 +118,6 @@ class RunnableAdd10(ParallelExecutionRunnable):
 
 
 class RunnableGetRandom(ParallelExecutionRunnable):
-    def init(self):
-        pass
 
     def run(self, data, path, origin_name=None):
         random_uuid = str(uuid.uuid4())

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2334,6 +2334,74 @@ def test_batch_with_timeout():
     assert termination_result == [[0, 1, 2], [3, 4, 5, 6], [7, 8, 9]]
 
 
+def test_batch_with_parallel_execution():
+    """Test that Batch step with full_event=True works correctly with ParallelExecution."""
+
+    class RunnableMultiplyBy2(ParallelExecutionRunnable):
+        def init(self):
+            pass
+
+        def run(self, data, path, origin_name=None):
+            if isinstance(data, list):
+                return [sub_value * 2 for sub_value in data]
+            return data * 2
+
+    class RunnableAdd10(ParallelExecutionRunnable):
+        def init(self):
+            pass
+
+        def run(self, data, path, origin_name=None):
+            if isinstance(data, list):
+                return [sub_value + 10 for sub_value in data]
+            return data + 10
+
+    runnables = [
+        RunnableMultiplyBy2("multiply"),
+        RunnableAdd10("add"),
+    ]
+
+    class MyParallelExecution(ParallelExecution):
+        def select_runnables(self, event):
+            return ["multiply", "add"]
+
+    parallel_execution = MyParallelExecution(
+        runnables,
+        execution_mechanism_by_runnable_name={
+            "multiply": "naive",
+            "add": "naive",
+        },
+    )
+
+    controller = build_flow(
+        [
+            SyncEmitSource(),
+            Batch(3, 100, full_event=True),
+            parallel_execution,
+            FlatMap(fn=lambda x: x.body, full_event=True),
+            Reduce([], lambda acc, x: append_and_return(acc, x)),
+        ]
+    ).run()
+
+    # Emit 10 events
+    for i in range(10):
+        controller.emit(i)
+
+    controller.terminate()
+    termination_result = controller.await_termination()
+
+    assert len(termination_result) == 10
+    assert termination_result[0] == {"multiply": 0, "add": 10}
+    assert termination_result[1] == {"multiply": 2, "add": 11}
+    assert termination_result[2] == {"multiply": 4, "add": 12}
+    assert termination_result[3] == {"multiply": 6, "add": 13}
+    assert termination_result[4] == {"multiply": 8, "add": 14}
+    assert termination_result[5] == {"multiply": 10, "add": 15}
+    assert termination_result[6] == {"multiply": 12, "add": 16}
+    assert termination_result[7] == {"multiply": 14, "add": 17}
+    assert termination_result[8] == {"multiply": 16, "add": 18}
+    assert termination_result[9] == {"multiply": 18, "add": 19}
+
+
 async def async_test_write_csv(tmpdir):
     file_path = f"{tmpdir}/test_write_csv/out.csv"
     controller = build_flow([AsyncEmitSource(), CSVTarget(file_path, columns=["n", "n*10"], header=True)]).run()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4016,6 +4016,7 @@ async def async_test_async_metadata_fields():
     assert result.key == "k1"
     assert result.body == body
 
+
 def test_async_metadata_fields():
     asyncio.run(async_test_async_metadata_fields())
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2382,8 +2382,6 @@ def test_basic_batch_with_parallel_execution():
         RunnableAdd10("add"),
         RunnableGetNow("now"),
     ]
-    source = SyncEmitSource()
-    batch_step = Batch(batch_size, 100, full_event=True)
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
@@ -2392,11 +2390,15 @@ def test_basic_batch_with_parallel_execution():
             "now": "naive",
         },
     )
-    flat_map = FlatMap(fn=lambda x: x.body, full_event=True)
-    reducer = Reduce([], lambda acc, x: append_and_return(acc, x))
-    source.to(batch_step).to(parallel_execution)
-    parallel_execution.to(flat_map).to(reducer)
-    controller = source.run()
+    controller = build_flow(
+        [
+            SyncEmitSource(),
+            Batch(max_events=batch_size, flush_after_seconds=100, full_event=True),
+            parallel_execution,
+            FlatMap(fn=lambda x: x.body, full_event=True),
+            Reduce(initial_value=[], fn=lambda acc, x: append_and_return(acc, x)),
+        ]
+    ).run()
 
     for i in range(number_of_events):
         sleep(0.2)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2367,6 +2367,10 @@ def test_batch_with_timeout():
 
 
 def test_basic_batch_with_parallel_execution():
+    asyncio.run(async_test_basic_batch_with_parallel_execution())
+
+
+async def async_test_basic_batch_with_parallel_execution():
     """Test that Batch step with full_event=True works correctly with ParallelExecution."""
     batch_size = 3
     number_of_events = 10
@@ -2386,8 +2390,8 @@ def test_basic_batch_with_parallel_execution():
     )
     controller = build_flow(
         [
-            SyncEmitSource(),
-            Batch(max_events=batch_size, full_event=True, flush_after_seconds=4),
+            AsyncEmitSource(),
+            Batch(max_events=batch_size, full_event=True, flush_after_seconds=2),
             parallel_execution,
             FlatMap(fn=lambda x: x.body, full_event=True),
             Complete(),
@@ -2395,27 +2399,22 @@ def test_basic_batch_with_parallel_execution():
         ]
     ).run()
 
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    def emit_event(i):
-        awaitable_result = controller.emit(i)
-        result = awaitable_result.await_result()
+    async def emit_event(i):
+        result = await controller.emit(i)
         # Verify each event has the expected fields after parallel execution
         assert "add" in result
         assert "multiply" in result
         assert "uuid" in result
         assert result["add"] == 10 + i
         assert result["multiply"] == i * 2
-        return result
 
-    # Emit events in parallel using ThreadPoolExecutor with batch_size threads
-    with ThreadPoolExecutor(max_workers=batch_size) as executor:
-        futures = [executor.submit(emit_event, i) for i in range(number_of_events)]
-        for future in as_completed(futures):
-            future.result()  # Wait for all to complete and raise any exceptions
-
-    controller.terminate()
-    termination_result = controller.await_termination()
+    # Emit events in parallel using asyncio
+    try:
+        tasks = [asyncio.create_task(emit_event(i)) for i in range(number_of_events)]
+        await asyncio.gather(*tasks)
+    finally:
+        await controller.terminate()
+        termination_result = await controller.await_termination()
     assert len(termination_result) == number_of_events
 
     previous_batch_number = -1
@@ -2430,6 +2429,10 @@ def test_basic_batch_with_parallel_execution():
 
 
 def test_batch_with_parallel_execution_split():
+    asyncio.run(async_test_batch_with_parallel_execution_split())
+
+
+async def async_test_batch_with_parallel_execution_split():
     """Test batched ParallelExecution with splitting to multiple outlets (len(outlets) > 1 path)."""
     batch_size = 3
     number_of_events = 10
@@ -2440,8 +2443,8 @@ def test_batch_with_parallel_execution_split():
         RunnableGetRandom("uuid"),
     ]
 
-    source = SyncEmitSource()
-    batch_step = Batch(max_events=batch_size, full_event=True, flush_after_seconds=4)
+    source = AsyncEmitSource()
+    batch_step = Batch(max_events=batch_size, full_event=True, flush_after_seconds=2)
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
@@ -2462,11 +2465,8 @@ def test_batch_with_parallel_execution_split():
 
     controller = source.run()
 
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    def emit_event(i):
-        awaitable_result = controller.emit(i)
-        result = awaitable_result.await_result()
+    async def emit_event(i):
+        result = await controller.emit(i)
         # Each event should get results from both branches (2 completions)
         assert len(result) == 3
         assert result["add"] == 10 + i
@@ -2474,14 +2474,12 @@ def test_batch_with_parallel_execution_split():
         assert "uuid" in result
         return result
 
-    # Emit events in parallel using ThreadPoolExecutor with batch_size threads
-    with ThreadPoolExecutor(max_workers=batch_size) as executor:
-        futures = [executor.submit(emit_event, i) for i in range(number_of_events)]
-        for future in as_completed(futures):
-            future.result()  # Wait for all to complete and raise any exceptions
-
-    controller.terminate()
-    termination_result = controller.await_termination()
+    try:
+        tasks = [asyncio.create_task(emit_event(i)) for i in range(number_of_events)]
+        await asyncio.gather(*tasks)
+    finally:
+        await controller.terminate()
+        termination_result = await controller.await_termination()
 
     # The final result should contain a duplicated value since the flow is split into two branches
     expected_number_of_events = number_of_events * 2
@@ -4019,10 +4017,6 @@ async def async_test_async_metadata_fields():
     result = result[0]
     assert result.key == "k1"
     assert result.body == body
-
-
-def test_async_metadata_fields():
-    asyncio.run(async_test_async_metadata_fields())
 
 
 def test_uuid():

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -41,6 +41,7 @@ from storey import (
     AsyncEmitSource,
     Batch,
     Choice,
+    Collector,
     Complete,
     CSVSource,
     CSVTarget,
@@ -100,6 +101,42 @@ class RaiseEx:
         if self._counter == self._raise_after:
             raise ATestException("test")
         return element
+
+
+class RunnableMultiplyBy2(ParallelExecutionRunnable):
+    def init(self):
+        pass
+
+    def run(self, data, path, origin_name=None):
+        if isinstance(data, list):
+            return [sub_value * 2 for sub_value in data]
+        return data * 2
+
+
+class RunnableAdd10(ParallelExecutionRunnable):
+    def init(self):
+        pass
+
+    def run(self, data, path, origin_name=None):
+        if isinstance(data, list):
+            return [sub_value + 10 for sub_value in data]
+        return data + 10
+
+
+class RunnableGetNow(ParallelExecutionRunnable):
+    def init(self):
+        pass
+
+    def run(self, data, path, origin_name=None):
+        now = datetime.now(timezone.utc)
+        if isinstance(data, list):
+            return [now] * len(data)
+        return now
+
+
+class MyParallelExecution(ParallelExecution):
+    def select_runnables(self, event):
+        return ["multiply", "add", "now"]
 
 
 def test_functional_flow():
@@ -2335,49 +2372,18 @@ def test_batch_with_timeout():
     assert termination_result == [[0, 1, 2], [3, 4, 5, 6], [7, 8, 9]]
 
 
-def test_batch_with_parallel_execution():
+def test_basic_batch_with_parallel_execution():
     """Test that Batch step with full_event=True works correctly with ParallelExecution."""
     batch_size = 3
     number_of_events = 10
-
-    class RunnableMultiplyBy2(ParallelExecutionRunnable):
-        def init(self):
-            pass
-
-        def run(self, data, path, origin_name=None):
-            if isinstance(data, list):
-                return [sub_value * 2 for sub_value in data]
-            return data * 2
-
-    class RunnableAdd10(ParallelExecutionRunnable):
-        def init(self):
-            pass
-
-        def run(self, data, path, origin_name=None):
-            if isinstance(data, list):
-                return [sub_value + 10 for sub_value in data]
-            return data + 10
-
-    class RunnableGetNow(ParallelExecutionRunnable):
-        def init(self):
-            pass
-
-        def run(self, data, path, origin_name=None):
-            now = datetime.now(timezone.utc)
-            if isinstance(data, list):
-                return [now] * len(data)
-            return now
 
     runnables = [
         RunnableMultiplyBy2("multiply"),
         RunnableAdd10("add"),
         RunnableGetNow("now"),
     ]
-
-    class MyParallelExecution(ParallelExecution):
-        def select_runnables(self, event):
-            return ["multiply", "add", "now"]
-
+    source = SyncEmitSource()
+    batch_step = Batch(batch_size, 100, full_event=True)
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
@@ -2386,16 +2392,17 @@ def test_batch_with_parallel_execution():
             "now": "naive",
         },
     )
+    flat_map1 = FlatMap(fn=lambda x: x.body, full_event=True)
 
-    controller = build_flow(
-        [
-            SyncEmitSource(),
-            Batch(batch_size, 100, full_event=True),
-            parallel_execution,
-            FlatMap(fn=lambda x: x.body, full_event=True),
-            Reduce([], lambda acc, x: append_and_return(acc, x)),
-        ]
-    ).run()
+    collector = Collector(expected_completions=2)
+    reducer = Reduce([], lambda acc, x: append_and_return(acc, x))
+
+    source.to(batch_step).to(parallel_execution)
+    parallel_execution.to(flat_map1).to(collector)
+
+    collector.to(reducer)
+
+    controller = source.run()
 
     for i in range(number_of_events):
         sleep(0.2)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -24,7 +24,6 @@ import traceback
 import uuid
 from datetime import datetime
 from random import choice
-from time import sleep
 from unittest.mock import MagicMock
 
 import fakeredis
@@ -41,7 +40,6 @@ from storey import (
     AsyncEmitSource,
     Batch,
     Choice,
-    Collector,
     Complete,
     CSVSource,
     CSVTarget,
@@ -2401,7 +2399,6 @@ def test_basic_batch_with_parallel_execution():
     ).run()
 
     for i in range(number_of_events):
-        sleep(0.2)
         controller.emit(i)
 
     controller.terminate()
@@ -2447,18 +2444,15 @@ def test_batch_with_parallel_execution_split():
 
     flat_map1 = FlatMap(fn=lambda x: x.body, full_event=True)
     flat_map2 = FlatMap(fn=lambda x: x.body, full_event=True)
-    collector = Collector(expected_completions=2)
     reducer = Reduce([], lambda acc, x: append_and_return(acc, x))
 
     source.to(batch_step).to(parallel_execution)
-    parallel_execution.to(flat_map1).to(collector)
-    parallel_execution.to(flat_map2).to(collector)
-    collector.to(reducer)
+    parallel_execution.to(flat_map1).to(reducer)
+    parallel_execution.to(flat_map2).to(reducer)
 
     controller = source.run()
 
     for i in range(number_of_events):
-        sleep(0.2)
         controller.emit(i)
 
     controller.terminate()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 import traceback
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from random import choice
 from time import sleep
 from unittest.mock import MagicMock

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -102,8 +102,6 @@ class RaiseEx:
 
 
 class RunnableMultiplyBy2(ParallelExecutionRunnable):
-    def init(self):
-        pass
 
     def run(self, data, path, origin_name=None):
         if isinstance(data, list):
@@ -112,8 +110,6 @@ class RunnableMultiplyBy2(ParallelExecutionRunnable):
 
 
 class RunnableAdd10(ParallelExecutionRunnable):
-    def init(self):
-        pass
 
     def run(self, data, path, origin_name=None):
         if isinstance(data, list):
@@ -2391,15 +2387,32 @@ def test_basic_batch_with_parallel_execution():
     controller = build_flow(
         [
             SyncEmitSource(),
-            Batch(max_events=batch_size, flush_after_seconds=4, full_event=True),
+            Batch(max_events=batch_size, full_event=True, flush_after_seconds=4),
             parallel_execution,
             FlatMap(fn=lambda x: x.body, full_event=True),
+            Complete(),
             Reduce(initial_value=[], fn=lambda acc, x: append_and_return(acc, x)),
         ]
     ).run()
 
-    for i in range(number_of_events):
-        controller.emit(i)
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    def emit_event(i):
+        awaitable_result = controller.emit(i)
+        result = awaitable_result.await_result()
+        # Verify each event has the expected fields after parallel execution
+        assert "add" in result
+        assert "multiply" in result
+        assert "uuid" in result
+        assert result["add"] == 10 + i
+        assert result["multiply"] == i * 2
+        return result
+
+    # Emit events in parallel using ThreadPoolExecutor with batch_size threads
+    with ThreadPoolExecutor(max_workers=batch_size) as executor:
+        futures = [executor.submit(emit_event, i) for i in range(number_of_events)]
+        for future in as_completed(futures):
+            future.result()  # Wait for all to complete and raise any exceptions
 
     controller.terminate()
     termination_result = controller.await_termination()
@@ -2408,10 +2421,6 @@ def test_basic_batch_with_parallel_execution():
     previous_batch_number = -1
     expected_uuid = ""
     for i in range(number_of_events):
-        expected_add = 10 + i
-        expected_multiply = i * 2
-        assert termination_result[i]["add"] == expected_add
-        assert termination_result[i]["multiply"] == expected_multiply
         batch_number = math.floor(i / batch_size)
         if previous_batch_number == -1 or batch_number != previous_batch_number:
             expected_uuid = termination_result[i]["uuid"]
@@ -2432,7 +2441,7 @@ def test_batch_with_parallel_execution_split():
     ]
 
     source = SyncEmitSource()
-    batch_step = Batch(max_events=batch_size, flush_after_seconds=4, full_event=True)
+    batch_step = Batch(max_events=batch_size, full_event=True, flush_after_seconds=4)
     parallel_execution = MyParallelExecution(
         runnables,
         execution_mechanism_by_runnable_name={
@@ -2444,16 +2453,32 @@ def test_batch_with_parallel_execution_split():
 
     flat_map1 = FlatMap(fn=lambda x: x.body, full_event=True)
     flat_map2 = FlatMap(fn=lambda x: x.body, full_event=True)
+    complete = Complete()
     reducer = Reduce([], lambda acc, x: append_and_return(acc, x))
 
     source.to(batch_step).to(parallel_execution)
-    parallel_execution.to(flat_map1).to(reducer)
+    parallel_execution.to(flat_map1).to(complete).to(reducer)
     parallel_execution.to(flat_map2).to(reducer)
 
     controller = source.run()
 
-    for i in range(number_of_events):
-        controller.emit(i)
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    def emit_event(i):
+        awaitable_result = controller.emit(i)
+        result = awaitable_result.await_result()
+        # Each event should get results from both branches (2 completions)
+        assert len(result) == 3
+        assert result["add"] == 10 + i
+        assert result["multiply"] == i * 2
+        assert "uuid" in result
+        return result
+
+    # Emit events in parallel using ThreadPoolExecutor with batch_size threads
+    with ThreadPoolExecutor(max_workers=batch_size) as executor:
+        futures = [executor.submit(emit_event, i) for i in range(number_of_events)]
+        for future in as_completed(futures):
+            future.result()  # Wait for all to complete and raise any exceptions
 
     controller.terminate()
     termination_result = controller.await_termination()


### PR DESCRIPTION
Supports batching with `ParallelExecution`, including sub_events handling on the first level and deepcopy handling.

Ticket:
[ML-12067](https://iguazio.atlassian.net/browse/ML-12067)

[ML-12067]: https://iguazio.atlassian.net/browse/ML-12067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ