### PR TITLE
Propagate streaming errors through `Collector` for monitoring

### DIFF
--- a/storey/dtypes.py
+++ b/storey/dtypes.py
@@ -137,15 +137,24 @@ class StreamCompletion:
 
     :param streaming_step: Name of the step that originated the stream.
     :param original_event: Reference to the original event that was streamed.
+    :param error: Optional error string (e.g. "ValueError: message") indicating
+        the stream terminated due to an error.
     """
 
-    def __init__(self, streaming_step: str, original_event: Event):
+    def __init__(
+        self,
+        streaming_step: str,
+        original_event: Event,
+        error: Optional[str] = None,
+    ):
         self.streaming_step = streaming_step
         self.original_event = original_event
+        self.error = error
 
     def __repr__(self):
         event_id = self.original_event.id if self.original_event else None
-        return f"StreamCompletion(streaming_step={self.streaming_step!r}, event_id={event_id!r})"
+        error_info = f", error={self.error!r}" if self.error else ""
+        return f"StreamCompletion(streaming_step={self.streaming_step!r}, event_id={event_id!r}{error_info})"
 
 
 class WindowBase:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -623,9 +623,6 @@ class _StreamingStepMixin:
         error_str = f"{type(generator_error).__name__}: {generator_error}" if generator_error else None
         await self._do_downstream(StreamCompletion(self.name, event, error=error_str))
 
-        if generator_error:
-            raise generator_error
-
 
 class _UnaryFunctionFlow(Flow):
     def __init__(

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -600,15 +600,31 @@ class _StreamingStepMixin:
         async_gen = gen_to_async_gen(generator) if inspect.isgenerator(generator) else generator
 
         chunk_id = 0
-        async for chunk_body in async_gen:
+        generator_error = None
+
+        # Use explicit iteration to separate generator errors from downstream errors.
+        # Only generator errors are caught; downstream errors propagate normally.
+        while True:
+            try:
+                chunk_body = await async_gen.__anext__()
+            except StopAsyncIteration:
+                break
+            except Exception as e:
+                generator_error = e
+                break
+
             chunk_event = self._user_fn_output_to_event(event, chunk_body)
             chunk_event.streaming_step = self.name
             chunk_event.chunk_id = chunk_id
             await self._do_downstream(chunk_event)
             chunk_id += 1
 
-        # Send completion signal
-        await self._do_downstream(StreamCompletion(self.name, event))
+        # Always send completion (even on error) so Collector can emit + clean up
+        error_str = f"{type(generator_error).__name__}: {generator_error}" if generator_error else None
+        await self._do_downstream(StreamCompletion(self.name, event, error=error_str))
+
+        if generator_error:
+            raise generator_error
 
 
 class _UnaryFunctionFlow(Flow):

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -32,7 +32,13 @@ import pyarrow
 import pytz
 from nuclio_sdk import QualifiedOffset
 
-from .dtypes import Event, StreamChunk, StreamCompletion, _termination_obj
+from .dtypes import (
+    Event,
+    StreamChunk,
+    StreamCompletion,
+    StreamingError,
+    _termination_obj,
+)
 from .flow import Complete, Flow, WithUUID
 from .queue import SimpleAsyncQueue
 from .utils import (
@@ -109,6 +115,10 @@ class AwaitableResult:
         if isinstance(first_item, StreamChunk):
             yield first_item.body
         elif isinstance(first_item, StreamCompletion):
+            if first_item.error:
+                if self._on_error:
+                    self._on_error()
+                raise StreamingError(first_item.error)
             completions_received = 1
 
         while completions_received < self._expected_number_of_results:
@@ -118,6 +128,10 @@ class AwaitableResult:
                     self._on_error()
                 raise copy.copy(item)
             if isinstance(item, StreamCompletion):
+                if item.error:
+                    if self._on_error:
+                        self._on_error()
+                    raise StreamingError(item.error)
                 completions_received += 1
             elif isinstance(item, StreamChunk):
                 yield item.body
@@ -514,6 +528,10 @@ class AsyncAwaitableResult:
         if isinstance(first_item, StreamChunk):
             yield first_item.body
         elif isinstance(first_item, StreamCompletion):
+            if first_item.error:
+                if self._on_error:
+                    await self._on_error()
+                raise StreamingError(first_item.error)
             completions_received = 1
 
         while completions_received < self._expected_number_of_results:
@@ -523,6 +541,10 @@ class AsyncAwaitableResult:
                     await self._on_error()
                 raise copy.copy(item)
             if isinstance(item, StreamCompletion):
+                if item.error:
+                    if self._on_error:
+                        await self._on_error()
+                    raise StreamingError(item.error)
                 completions_received += 1
             elif isinstance(item, StreamChunk):
                 yield item.body

--- a/storey/steps/collector.py
+++ b/storey/steps/collector.py
@@ -87,9 +87,13 @@ class Collector(Flow):
                 # Stream is complete - emit collected result
                 # Use first_event if we have chunks, otherwise use original_event from completion (empty stream)
                 base_event = stream_data["first_event"] or event.original_event
-                collected_body = [chunk.body for chunk in stream_data["chunks"]]
-                if len(collected_body) == 1:
-                    collected_body = collected_body[0]
+
+                if event.error:
+                    collected_body = {"error": event.error}
+                else:
+                    collected_body = [chunk.body for chunk in stream_data["chunks"]]
+                    if len(collected_body) == 1:
+                        collected_body = collected_body[0]
 
                 # Copy the original event to preserve all attributes (important for offset management)
                 collected_event = copy.copy(base_event)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -6125,7 +6125,6 @@ class TestBatchWithParallelExecution:
     def test_batch_error_handling_multiple_runnables(self):
         asyncio.run(self.async_test_batch_error_handling_multiple_runnables())
 
-    @pytest.mark.asyncio
     async def async_test_batch_error_handling_multiple_runnables(self):
         """Test error handling in batched parallel execution with multiple runnables."""
         flush_after_seconds = 0.3

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -92,6 +92,23 @@ class TestStreamingPrimitives:
         assert "StreamCompletion" in repr(completion)
         assert "my_step" in repr(completion)
 
+    def test_stream_completion_with_error(self):
+        """Test StreamCompletion with error string."""
+        event = Event(body="test", id="123")
+        completion = StreamCompletion("test_step", event, error="ValueError: test error")
+        assert completion.streaming_step == "test_step"
+        assert completion.original_event is event
+        assert completion.error == "ValueError: test error"
+
+    def test_stream_completion_with_error_repr(self):
+        """Test StreamCompletion repr includes error string."""
+        event = Event(body="test", id="abc")
+        completion = StreamCompletion("my_step", event, error="RuntimeError: something went wrong")
+        repr_str = repr(completion)
+        assert "StreamCompletion" in repr_str
+        assert "my_step" in repr_str
+        assert "RuntimeError" in repr_str
+
 
 class TestIsGenerator:
     """Tests for the _is_generator utility function."""
@@ -649,6 +666,157 @@ class TestCollector:
 
         asyncio.run(_test())
 
+    def test_collector_streaming_error_emits_error_dict(self):
+        """Test that Collector emits an error dict when a generator raises mid-stream.
+
+        When a streaming generator raises an exception, the Collector should emit
+        an event with body={"error": "ExceptionType: message"} matching the
+        non-streaming error format from ParallelExecutionRunnable._run().
+        """
+
+        def error_stream(x):
+            yield f"{x}_chunk_0"
+            raise ValueError("Generator error mid-stream")
+
+        controller = build_flow(
+            [
+                SyncEmitSource(),
+                Map(error_stream),
+                Collector(),
+                Reduce([], lambda acc, x: acc + [x]),
+            ]
+        ).run()
+
+        controller.emit("test")
+        controller.terminate()
+
+        # The error is raised but Collector still emits the error event
+        with pytest.raises(ValueError, match="Generator error mid-stream"):
+            controller.await_termination()
+
+    def test_collector_streaming_error_body_format(self):
+        """Verify the exact format of error body emitted by Collector."""
+
+        def error_stream(x):
+            yield f"{x}_chunk_0"
+            raise RuntimeError("stream failure")
+
+        controller = build_flow(
+            [
+                SyncEmitSource(),
+                Map(error_stream),
+                Collector(),
+                Reduce([], lambda acc, x: acc + [x], full_event=True),
+            ]
+        ).run()
+
+        controller.emit("test")
+        controller.terminate()
+
+        with pytest.raises(RuntimeError, match="stream failure"):
+            controller.await_termination()
+
+    def test_collector_streaming_error_sets_stream_collected(self):
+        """Test that Collector sets stream_collected=True even on error."""
+
+        async def _test():
+            collected_events = []
+
+            class EventCapture(Map):
+                def __init__(self, **kwargs):
+                    super().__init__(fn=lambda x: x, **kwargs)
+
+                async def _do(self, event):
+                    if hasattr(event, "stream_collected"):
+                        collected_events.append(event)
+                    return await super()._do(event)
+
+            def error_stream(x):
+                yield f"{x}_chunk_0"
+                raise ValueError("test error")
+
+            source = AsyncEmitSource()
+            streaming_map = Map(error_stream)
+            collector = Collector()
+            capture = EventCapture()
+            reducer = Reduce([], lambda acc, x: acc + [x])
+
+            source.to(streaming_map).to(collector).to(capture).to(reducer)
+
+            controller = source.run()
+
+            await controller.emit("test")
+            await controller.terminate()
+
+            with pytest.raises(ValueError, match="test error"):
+                await controller.await_termination()
+
+            # Verify we captured an event with stream_collected=True and error body
+            assert len(collected_events) == 1
+            event = collected_events[0]
+            assert event.stream_collected is True
+            assert isinstance(event.body, dict)
+            assert "error" in event.body
+            assert "ValueError" in event.body["error"]
+            assert "test error" in event.body["error"]
+
+        asyncio.run(_test())
+
+    def test_async_collector_streaming_error(self):
+        """Async version: Test streaming error propagation through Collector."""
+
+        async def _test():
+
+            def error_stream(x):
+                yield f"{x}_chunk_0"
+                raise RuntimeError("async stream failure")
+
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    Map(error_stream),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
+
+            await controller.emit("test")
+            await controller.terminate()
+
+            with pytest.raises(RuntimeError, match="async stream failure"):
+                await controller.await_termination()
+
+        asyncio.run(_test())
+
+    def test_collector_streaming_error_cleans_up(self):
+        """Verify that Collector cleans up _collected_streams after error (no memory leak)."""
+
+        async def _test():
+
+            def error_stream(x):
+                yield f"{x}_chunk_0"
+                raise ValueError("cleanup test error")
+
+            source = AsyncEmitSource()
+            streaming_map = Map(error_stream)
+            collector = Collector()
+            reducer = Reduce([], lambda acc, x: acc + [x])
+
+            source.to(streaming_map).to(collector).to(reducer)
+
+            controller = source.run()
+
+            await controller.emit("test")
+            await controller.terminate()
+
+            with pytest.raises(ValueError, match="cleanup test error"):
+                await controller.await_termination()
+
+            # Verify collector cleaned up (no memory leak)
+            assert len(collector._collected_streams) == 0
+
+        asyncio.run(_test())
+
 
 class TestCompleteStreaming:
     """Tests for Complete step streaming support."""
@@ -914,9 +1082,9 @@ class TestStreamingErrors:
 
             assert inspect.isgenerator(result)
 
-            # Collect chunks until error
+            # Collect chunks until error - consumer gets StreamingError wrapping the message
             chunks = []
-            with pytest.raises(ValueError, match="Generator error mid-stream"):
+            with pytest.raises(StreamingError, match="Generator error mid-stream"):
                 for chunk in result:
                     chunks.append(chunk)
 
@@ -924,7 +1092,7 @@ class TestStreamingErrors:
             assert chunks == ["test_chunk_0"]
         finally:
             controller.terminate()
-            # Error is also propagated through termination
+            # Original exception propagates through termination
             with pytest.raises(ValueError, match="Generator error mid-stream"):
                 controller.await_termination()
 
@@ -949,9 +1117,9 @@ class TestStreamingErrors:
 
                 assert inspect.isasyncgen(result)
 
-                # Collect chunks until error
+                # Collect chunks until error - consumer gets StreamingError wrapping the message
                 chunks = []
-                with pytest.raises(ValueError, match="Generator error mid-stream"):
+                with pytest.raises(StreamingError, match="Generator error mid-stream"):
                     async for chunk in result:
                         chunks.append(chunk)
 
@@ -959,7 +1127,7 @@ class TestStreamingErrors:
                 assert chunks == ["test_chunk_0"]
             finally:
                 await controller.terminate()
-                # Error is also propagated through termination
+                # Original exception propagates through termination
                 with pytest.raises(ValueError, match="Generator error mid-stream"):
                     await controller.await_termination()
 
@@ -1368,7 +1536,7 @@ class TestParallelExecutionStreaming:
             controller.await_termination()
 
     @pytest.mark.parametrize(
-        "execution_mechanism,expected_error",
+        "execution_mechanism,expected_termination_error",
         [
             (ParallelExecutionMechanisms.naive, ValueError),
             (ParallelExecutionMechanisms.thread_pool, ValueError),
@@ -1377,7 +1545,7 @@ class TestParallelExecutionStreaming:
             (ParallelExecutionMechanisms.dedicated_process, RuntimeError),
         ],
     )
-    def test_parallel_execution_streaming_error_propagation(self, execution_mechanism, expected_error):
+    def test_parallel_execution_streaming_error_propagation(self, execution_mechanism, expected_termination_error):
         """Test that errors in streaming are propagated correctly."""
         runnable = ErrorStreamingRunnable(name="error_streamer")
         controller = build_flow(
@@ -1395,17 +1563,17 @@ class TestParallelExecutionStreaming:
             awaitable = controller.emit("test")
             result = awaitable.await_result()
             assert inspect.isgenerator(result)
-            # Should get first chunk, then error
+            # Should get first chunk, then StreamingError wrapping the error message
             chunks = []
-            with pytest.raises(expected_error, match="Simulated streaming error"):
+            with pytest.raises(StreamingError, match="Simulated streaming error"):
                 for chunk in result:
                     chunks.append(chunk)
             # Verify we got the first chunk before the error
             assert chunks == ["test_chunk_0"]
         finally:
             controller.terminate()
-            # Error is also propagated through termination
-            with pytest.raises(expected_error, match="Simulated streaming error"):
+            # Original exception propagates through termination
+            with pytest.raises(expected_termination_error, match="Simulated streaming error"):
                 controller.await_termination()
 
     def test_parallel_execution_streaming_single_runnable_sets_metadata(self):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -687,34 +687,49 @@ class TestCollector:
             ]
         ).run()
 
-        controller.emit("test")
-        controller.terminate()
+        try:
+            controller.emit("test")
+        finally:
+            controller.terminate()
+            result = controller.await_termination()
 
-        # The error is raised but Collector still emits the error event
-        with pytest.raises(ValueError, match="Generator error mid-stream"):
-            controller.await_termination()
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert "error" in result[0]
+        assert "ValueError" in result[0]["error"]
+        assert "Generator error mid-stream" in result[0]["error"]
 
-    def test_collector_streaming_error_body_format(self):
-        """Verify the exact format of error body emitted by Collector."""
+    def test_async_collector_streaming_error(self):
+        """Async version: Test streaming error propagation through Collector."""
 
-        def error_stream(x):
-            yield f"{x}_chunk_0"
-            raise RuntimeError("stream failure")
+        async def _test():
 
-        controller = build_flow(
-            [
-                SyncEmitSource(),
-                Map(error_stream),
-                Collector(),
-                Reduce([], lambda acc, x: acc + [x], full_event=True),
-            ]
-        ).run()
+            def error_stream(x):
+                yield f"{x}_chunk_0"
+                raise RuntimeError("async stream failure")
 
-        controller.emit("test")
-        controller.terminate()
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    Map(error_stream),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
 
-        with pytest.raises(RuntimeError, match="stream failure"):
-            controller.await_termination()
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
+                result = await controller.await_termination()
+
+            assert len(result) == 1
+            assert isinstance(result[0], dict)
+            assert "error" in result[0]
+            assert "RuntimeError" in result[0]["error"]
+            assert "async stream failure" in result[0]["error"]
+
+        asyncio.run(_test())
 
     def test_collector_streaming_error_sets_stream_collected(self):
         """Test that Collector sets stream_collected=True even on error."""
@@ -745,10 +760,10 @@ class TestCollector:
 
             controller = source.run()
 
-            await controller.emit("test")
-            await controller.terminate()
-
-            with pytest.raises(ValueError, match="test error"):
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
                 await controller.await_termination()
 
             # Verify we captured an event with stream_collected=True and error body
@@ -759,32 +774,6 @@ class TestCollector:
             assert "error" in event.body
             assert "ValueError" in event.body["error"]
             assert "test error" in event.body["error"]
-
-        asyncio.run(_test())
-
-    def test_async_collector_streaming_error(self):
-        """Async version: Test streaming error propagation through Collector."""
-
-        async def _test():
-
-            def error_stream(x):
-                yield f"{x}_chunk_0"
-                raise RuntimeError("async stream failure")
-
-            controller = build_flow(
-                [
-                    AsyncEmitSource(),
-                    Map(error_stream),
-                    Collector(),
-                    Reduce([], lambda acc, x: acc + [x]),
-                ]
-            ).run()
-
-            await controller.emit("test")
-            await controller.terminate()
-
-            with pytest.raises(RuntimeError, match="async stream failure"):
-                await controller.await_termination()
 
         asyncio.run(_test())
 
@@ -806,10 +795,10 @@ class TestCollector:
 
             controller = source.run()
 
-            await controller.emit("test")
-            await controller.terminate()
-
-            with pytest.raises(ValueError, match="cleanup test error"):
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
                 await controller.await_termination()
 
             # Verify collector cleaned up (no memory leak)
@@ -1062,7 +1051,7 @@ class TestStreamingErrors:
         asyncio.run(_test())
 
     def test_streaming_generator_raises_error(self):
-        """Test that error in generator mid-stream propagates without hanging."""
+        """Test that error in generator mid-stream is delivered to consumer without killing the flow."""
 
         def error_stream(x):
             yield f"{x}_chunk_0"
@@ -1082,7 +1071,7 @@ class TestStreamingErrors:
 
             assert inspect.isgenerator(result)
 
-            # Collect chunks until error - consumer gets StreamingError wrapping the message
+            # Consumer gets StreamingError wrapping the error message
             chunks = []
             with pytest.raises(StreamingError, match="Generator error mid-stream"):
                 for chunk in result:
@@ -1092,12 +1081,10 @@ class TestStreamingErrors:
             assert chunks == ["test_chunk_0"]
         finally:
             controller.terminate()
-            # Original exception propagates through termination
-            with pytest.raises(ValueError, match="Generator error mid-stream"):
-                controller.await_termination()
+            controller.await_termination()
 
     def test_async_streaming_generator_raises_error(self):
-        """Async version: Test that error in generator mid-stream propagates without hanging."""
+        """Async version: Test that error in generator mid-stream is delivered to consumer without killing the flow."""
 
         async def _test():
             def error_stream(x):
@@ -1117,7 +1104,7 @@ class TestStreamingErrors:
 
                 assert inspect.isasyncgen(result)
 
-                # Collect chunks until error - consumer gets StreamingError wrapping the message
+                # Consumer gets StreamingError wrapping the error message
                 chunks = []
                 with pytest.raises(StreamingError, match="Generator error mid-stream"):
                     async for chunk in result:
@@ -1127,9 +1114,7 @@ class TestStreamingErrors:
                 assert chunks == ["test_chunk_0"]
             finally:
                 await controller.terminate()
-                # Original exception propagates through termination
-                with pytest.raises(ValueError, match="Generator error mid-stream"):
-                    await controller.await_termination()
+                await controller.await_termination()
 
         asyncio.run(_test())
 
@@ -1536,17 +1521,16 @@ class TestParallelExecutionStreaming:
             controller.await_termination()
 
     @pytest.mark.parametrize(
-        "execution_mechanism,expected_termination_error",
+        "execution_mechanism",
         [
-            (ParallelExecutionMechanisms.naive, ValueError),
-            (ParallelExecutionMechanisms.thread_pool, ValueError),
-            # Process-based mechanisms wrap errors in RuntimeError
-            (ParallelExecutionMechanisms.process_pool, RuntimeError),
-            (ParallelExecutionMechanisms.dedicated_process, RuntimeError),
+            ParallelExecutionMechanisms.naive,
+            ParallelExecutionMechanisms.thread_pool,
+            ParallelExecutionMechanisms.process_pool,
+            ParallelExecutionMechanisms.dedicated_process,
         ],
     )
-    def test_parallel_execution_streaming_error_propagation(self, execution_mechanism, expected_termination_error):
-        """Test that errors in streaming are propagated correctly."""
+    def test_parallel_execution_streaming_error_propagation(self, execution_mechanism):
+        """Test that streaming errors are delivered to consumer without killing the flow."""
         runnable = ErrorStreamingRunnable(name="error_streamer")
         controller = build_flow(
             [
@@ -1563,7 +1547,7 @@ class TestParallelExecutionStreaming:
             awaitable = controller.emit("test")
             result = awaitable.await_result()
             assert inspect.isgenerator(result)
-            # Should get first chunk, then StreamingError wrapping the error message
+            # Consumer gets StreamingError wrapping the error message
             chunks = []
             with pytest.raises(StreamingError, match="Simulated streaming error"):
                 for chunk in result:
@@ -1572,9 +1556,7 @@ class TestParallelExecutionStreaming:
             assert chunks == ["test_chunk_0"]
         finally:
             controller.terminate()
-            # Original exception propagates through termination
-            with pytest.raises(expected_termination_error, match="Simulated streaming error"):
-                controller.await_termination()
+            controller.await_termination()
 
     def test_parallel_execution_streaming_single_runnable_sets_metadata(self):
         """Test that streaming ParallelExecution with single runnable sets timing metadata.


### PR DESCRIPTION
This fix is needed to complete https://github.com/mlrun/mlrun/pull/9343 ([ML-12182](https://iguazio.atlassian.net/browse/ML-12182)).

When a streaming generator raises an exception, the error was not propagated through the normal graph pipeline — the `Collector` never emitted an event, causing a memory leak in `_collected_streams` and preventing downstream consumers (e.g. model monitoring) from tracking the error.

### Changes
- **`StreamCompletion`**: Add optional `error: str` field to carry the error type and message (e.g. `"ValueError: something failed"`)
- **`_emit_streaming_chunks`**: Use explicit `__anext__()` iteration to separate generator errors from downstream errors. Always send `StreamCompletion` (even on error) so `Collector` can emit and clean up. The generator error is **not** re-raised — the flow stays alive and the error propagates only via `StreamCompletion`.
- **`Collector`**: When `StreamCompletion.error` is set, emit `body={"error": error_string}` instead of collected chunks, matching the format used by `ParallelExecution` for non-streaming errors.
- **`AwaitableResult` / `AsyncAwaitableResult`**: Check `StreamCompletion.error` in the stream generators and raise `StreamingError` wrapping the error string, so consumers are notified of the failure.
- Remove unrelated but erroneous `@pytest.mark.asyncio` annotation

### Tests
- `StreamCompletion` with error field (construction + repr)
- `Collector` error propagation: error dict format, `stream_collected` attribute, cleanup of `_collected_streams`
- Streaming generator errors deliver `StreamingError` to consumers via `AwaitableResult`; `await_termination()` completes normally
- `ParallelExecution` streaming error propagation across execution mechanisms

[ML-12182]: https://iguazio.atlassian.net/browse/ML-12182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ