### PR TITLE
Fix premature Kafka offset commit in AsyncEmitSource

### DIFF
--- a/storey/sources.py
+++ b/storey/sources.py
@@ -790,9 +790,10 @@ class AsyncEmitSource(Flow):
                     await self._q.get()
                 self._raise_on_error()
             finally:
-                # Commit on termination regardless of errors (ML-11919)
-                await _commit_handled_events(self._outstanding_offsets, committer, self.logger, commit_all=True)
                 if event is _termination_obj or self._ex:
+                    # Commit on termination regardless of errors (ML-11919).
+                    # Must only run on termination/error, NOT every event (ML-12076).
+                    await _commit_handled_events(self._outstanding_offsets, committer, self.logger, commit_all=True)
                     for closeable in self._closeables:
                         try:
                             maybe_coroutine = closeable.close()

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -791,7 +791,7 @@ class AsyncEmitSource(Flow):
                 self._raise_on_error()
             finally:
                 if event is _termination_obj or self._ex:
-                    # Commit on termination/error only, not every event (ML-12076).
+                    # Commit on termination/error only, not every event (ML-11979).
                     await _commit_handled_events(self._outstanding_offsets, committer, self.logger, commit_all=True)
                     for closeable in self._closeables:
                         try:

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -791,8 +791,7 @@ class AsyncEmitSource(Flow):
                 self._raise_on_error()
             finally:
                 if event is _termination_obj or self._ex:
-                    # Commit on termination regardless of errors (ML-11919).
-                    # Must only run on termination/error, NOT every event (ML-12076).
+                    # Commit on termination/error only, not every event (ML-12076).
                     await _commit_handled_events(self._outstanding_offsets, committer, self.logger, commit_all=True)
                     for closeable in self._closeables:
                         try:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -461,7 +461,7 @@ def test_offset_not_committed_prematurely():
 
 
 async def async_offset_not_committed_prematurely_with_batch():
-    """ML-12076: AsyncEmitSource must not commit offsets for events still in batch buffers."""
+    """ML-11979: AsyncEmitSource must not commit offsets for events still in batch buffers."""
     platform = Committer()
     context = CommitterContext(platform)
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -487,12 +487,9 @@ async def async_offset_not_committed_prematurely_with_batch():
     # Events are still in the Batch buffer (not flushed).
     # Offsets must NOT be committed — they are not fully processed.
     offsets_before = copy.copy(platform.offsets)
-    try:
-        assert (
-            offsets_before == {}
-        ), f"ML-12076: Offsets committed prematurely while events in batch buffer: {offsets_before}"
-    finally:
-        termination_result = await controller.terminate(wait=True)
+    assert offsets_before == {}, f"Offsets committed prematurely while events in batch buffer: {offsets_before}"
+
+    termination_result = await controller.terminate(wait=True)
 
     # After termination, Batch._emit_all flushes remaining events,
     # then commit_all=True fires correctly.
@@ -501,7 +498,6 @@ async def async_offset_not_committed_prematurely_with_batch():
     assert offsets_after == {("/", 0): 5}
 
 
-# ML-12076
 def test_async_offset_not_committed_prematurely_with_batch():
     asyncio.run(async_offset_not_committed_prematurely_with_batch())
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -460,6 +460,52 @@ def test_offset_not_committed_prematurely():
     assert offsets == {("/", i): num_records_per_shard for i in range(num_shards)}
 
 
+async def async_offset_not_committed_prematurely_with_batch():
+    """ML-12076: AsyncEmitSource must not commit offsets for events still in batch buffers."""
+    platform = Committer()
+    context = CommitterContext(platform)
+
+    controller = build_flow(
+        [
+            AsyncEmitSource(context=context, explicit_ack=True, max_wait_before_commit=1),
+            Batch(max_events=100, flush_after_seconds=120),
+            Reduce(0, lambda acc, x: acc + len(x)),
+        ]
+    ).run()
+
+    # Emit 5 events to shard 0 — all stay in Batch buffer (batch needs 100 to flush)
+    for offset in range(1, 6):
+        event = Event(offset)
+        event.shard_id = 0
+        event.offset = offset
+        await controller.emit(event)
+    del event
+
+    # Wait for the commit loop to run (max_wait_before_commit=1s)
+    await asyncio.sleep(3)
+
+    # Events are still in the Batch buffer (not flushed).
+    # Offsets must NOT be committed — they are not fully processed.
+    offsets_before = copy.copy(platform.offsets)
+    try:
+        assert (
+            offsets_before == {}
+        ), f"ML-12076: Offsets committed prematurely while events in batch buffer: {offsets_before}"
+    finally:
+        termination_result = await controller.terminate(wait=True)
+
+    # After termination, Batch._emit_all flushes remaining events,
+    # then commit_all=True fires correctly.
+    assert termination_result == 5
+    offsets_after = copy.copy(platform.offsets)
+    assert offsets_after == {("/", 0): 5}
+
+
+# ML-12076
+def test_async_offset_not_committed_prematurely_with_batch():
+    asyncio.run(async_offset_not_committed_prematurely_with_batch())
+
+
 async def async_offset_commit_error():
     platform = BadCommitter()
     logger = MockLogger()


### PR DESCRIPTION
## Summary

- **ML-11919** moved `commit_all=True` from the `try` block (termination-only) into the `finally` block of `AsyncEmitSource._run_loop()`, causing it to fire on **every event iteration**. This commits Kafka offsets for events still held in batch buffers (not yet written to TSDB/Parquet), so on rebalance those events are permanently lost.
- Move `commit_all=True` inside the `if event is _termination_obj or self._ex:` guard, preserving ML-11919 intent (commit on error/termination) while preventing premature commits during normal processing.
- `SyncEmitSource` does **not** have this bug — its `commit_all=True` is already correctly scoped to the termination path.

## Changes

- **`storey/sources.py`**: Move `commit_all=True` call inside termination/error guard in the `finally` block
- **`tests/test_flow.py`**: Add `test_async_offset_not_committed_prematurely_with_batch` — proves offsets are not committed while events sit in `Batch` buffer

## Test plan

- [x] New test `test_async_offset_not_committed_prematurely_with_batch` fails on current code, passes after fix
- [x] ML-11919 regression test `test_async_offset_commit_error_on_termination` still passes
- [x] All 11 offset-related tests pass (`pytest tests/test_flow.py -k "offset" -xvs`)
- [x] Verified in production (vmdev61, 1500 endpoints): **0% data loss** with fix (was 86.7% without)

## Production evidence

| Test | Config | TSDB endpoints | Loss % |
|------|--------|---------------|--------|
| repro-dl-553ef2 | No fix | 199/1500 | 86.7% |
| **repro-dl-99b3aa** | **With fix** | **1500/1500** | **0%** |

Fixes: ML-11979