### PR TITLE
Replace COPY with INSERT ON CONFLICT for dedup support

### DIFF
--- a/integration/test_timescaledb.py
+++ b/integration/test_timescaledb.py
@@ -841,3 +841,72 @@ def test_timescaledb_retry_retry_configuration_defaults(timescaledb):
     assert default_target._max_retries == TimescaleDBTarget.DEFAULT_MAX_RETRIES
     assert default_target._retry_delay == TimescaleDBTarget.DEFAULT_RETRY_DELAY
     assert default_target.MAX_DEADLOCK_RETRIES == 3
+
+
+def test_timescaledb_dedup_with_unique_constraint(table_cleanup):
+    """ML-11979: Duplicate events from Kafka rebalance must be silently dropped
+    when the table has a UNIQUE constraint.
+
+    TimescaleDBTarget uses INSERT ... ON CONFLICT DO NOTHING, so re-delivered
+    events with the same (endpoint_id, end_infer_time) are deduplicated at write time.
+    """
+    table_name = f"test_dedup_{uuid4().hex[:8]}"
+    table_cleanup.add_table(table_name)
+
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("CREATE EXTENSION IF NOT EXISTS timescaledb;")
+            cursor.execute(f"DROP TABLE IF EXISTS {table_name};")
+            cursor.execute(
+                f"""
+                CREATE TABLE {table_name} (
+                    end_infer_time TIMESTAMPTZ NOT NULL,
+                    endpoint_id VARCHAR(64),
+                    latency DOUBLE PRECISION,
+                    UNIQUE (endpoint_id, end_infer_time)
+                );
+                """
+            )
+            cursor.execute(
+                f"SELECT create_hypertable('{table_name}', 'end_infer_time', "
+                f"chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);"
+            )
+
+    columns = ["endpoint_id", "latency"]
+    controller = build_flow(
+        [
+            SyncEmitSource(),
+            TimescaleDBTarget(
+                dsn=dsn,
+                table=table_name,
+                time_col="end_infer_time",
+                columns=columns,
+                max_events=10,
+            ),
+        ]
+    ).run()
+
+    # Emit 3 unique events
+    events = [
+        {"end_infer_time": "2024-01-01 00:00:01+00", "endpoint_id": "ep1", "latency": 0.1},
+        {"end_infer_time": "2024-01-01 00:00:02+00", "endpoint_id": "ep1", "latency": 0.2},
+        {"end_infer_time": "2024-01-01 00:00:03+00", "endpoint_id": "ep2", "latency": 0.3},
+    ]
+    for event in events:
+        controller.emit(event)
+
+    # Re-emit the same 3 events (simulating Kafka rebalance re-delivery)
+    for event in events:
+        controller.emit(event)
+
+    controller.terminate()
+    controller.await_termination()
+
+    # Only 3 unique rows should exist, not 6
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            count = cursor.fetchone()[0]
+            assert count == 3, (
+                f"ML-11979: Expected 3 unique rows but got {count}. " f"Duplicates were not deduplicated at write time."
+            )

--- a/storey/timescaledb_target.py
+++ b/storey/timescaledb_target.py
@@ -77,7 +77,7 @@ class TimescaleDBTarget(_Batching, _Writer):
         - The target table must be created as a TimescaleDB hypertable before use
         - The time column should be a timestamp type, preferably TIMESTAMPTZ for timezone awareness
         - Events are written using INSERT ... ON CONFLICT DO NOTHING via executemany,
-          which silently deduplicates rows when the table has a UNIQUE constraint
+          which silently deduplicates rows when the table has a UNIQUE constraint (with some performance penalty)
         - Connection pooling is handled automatically with proper cleanup on termination
         - Built-in retry logic handles deadlocks (fast retry) and connection issues (exponential backoff)
         - Deadlock retries: 3 attempts with 0.1s, 0.2s, 0.4s delays (with jitter)
@@ -133,8 +133,8 @@ class TimescaleDBTarget(_Batching, _Writer):
         # Database connection configuration
         self._dsn = dsn
         # Connection pool: Single connection is sufficient for most use cases since:
-        # 1. COPY operations are already bulk-optimized and very fast
-        # 2. Multiple concurrent COPY operations may cause lock contention
+        # 1. executemany operations are already bulk-optimized and very fast
+        # 2. Multiple concurrent write operations may cause lock contention
         # 3. Most data flows process batches sequentially, not concurrently
         # For high-throughput scenarios with concurrent batches, consider increasing pool size
         self._pool: Optional[AsyncConnectionPool] = None  # Connection pool will be created lazily during first use

--- a/storey/timescaledb_target.py
+++ b/storey/timescaledb_target.py
@@ -76,7 +76,8 @@ class TimescaleDBTarget(_Batching, _Writer):
     Note:
         - The target table must be created as a TimescaleDB hypertable before use
         - The time column should be a timestamp type, preferably TIMESTAMPTZ for timezone awareness
-        - Events are written using PostgreSQL's COPY protocol for optimal performance
+        - Events are written using INSERT ... ON CONFLICT DO NOTHING via executemany,
+          which silently deduplicates rows when the table has a UNIQUE constraint
         - Connection pooling is handled automatically with proper cleanup on termination
         - Built-in retry logic handles deadlocks (fast retry) and connection issues (exponential backoff)
         - Deadlock retries: 3 attempts with 0.1s, 0.2s, 0.4s delays (with jitter)
@@ -297,8 +298,9 @@ class TimescaleDBTarget(_Batching, _Writer):
 
         This method performs the core data writing functionality:
         1. Ensures the connection pool is initialized
-        2. Converts dictionary events to tuples for efficient COPY operations
-        3. Uses PostgreSQL's COPY protocol for high-performance bulk inserts
+        2. Converts dictionary events to tuples with consistent column ordering
+        3. Uses INSERT ... ON CONFLICT DO NOTHING via executemany for bulk writes
+           with automatic deduplication when the table has a UNIQUE constraint
         4. Maintains proper column ordering for TimescaleDB compatibility
 
         Args:
@@ -318,8 +320,8 @@ class TimescaleDBTarget(_Batching, _Writer):
         # Get table schema for validation on first use
         schema = await self._get_table_schema()
 
-        # Convert dictionaries to tuples for copy_records_to_table
-        # PostgreSQL's COPY protocol requires data in tuple format with consistent column ordering
+        # Convert dictionaries to tuples for executemany
+        # Consistent column ordering required for parameterized INSERT
         # Validate against schema to catch missing required columns early
 
         records = []
@@ -354,20 +356,20 @@ class TimescaleDBTarget(_Batching, _Writer):
 
             async with self._pool.connection() as conn:
                 async with conn.cursor() as cur:
-                    # Use PostgreSQL's COPY protocol for optimal performance
-                    # This is significantly faster than individual INSERT statements
                     table_identifier = sql.Identifier(self._table)
                     if self._schema:
                         table_identifier = sql.Identifier(self._schema, self._table)
 
                     column_identifiers = [sql.Identifier(col) for col in self._column_names]
-                    copy_query = sql.SQL("COPY {} ({}) FROM STDIN").format(
-                        table_identifier, sql.SQL(", ").join(column_identifiers)
+                    placeholders = sql.SQL(", ").join([sql.Placeholder()] * len(self._column_names))
+
+                    insert_query = sql.SQL("INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO NOTHING").format(
+                        table_identifier,
+                        sql.SQL(", ").join(column_identifiers),
+                        placeholders,
                     )
 
-                    async with cur.copy(copy_query) as copy_context:
-                        for record in records:
-                            await copy_context.write_row(record)
+                    await cur.executemany(insert_query, records)
 
         await self._execute_with_retry(batch_write_operation)
 


### PR DESCRIPTION
## Summary

- Replace PostgreSQL COPY protocol with `executemany` + `INSERT ... ON CONFLICT DO NOTHING` in `TimescaleDBTarget`
- When the target table has a UNIQUE constraint, duplicate rows from Kafka rebalance re-delivery are silently dropped at write time
- Tables without UNIQUE constraints are unaffected — `ON CONFLICT DO NOTHING` with no matching constraint behaves as a regular INSERT

## Changes Made

- **`storey/timescaledb_target.py`**: Replace `cur.copy(COPY ... FROM STDIN)` with `cur.executemany(INSERT ... ON CONFLICT DO NOTHING, records)`
- **`integration/test_timescaledb.py`**: Add `test_timescaledb_dedup_with_unique_constraint` — creates table with UNIQUE(endpoint_id, end_infer_time), emits 3 events + 3 duplicates, verifies only 3 rows stored

## Testing

- All 24 integration tests pass (including new dedup test)
- Tested against TimescaleDB on vmdev61

## Reference

- Jira: ML-11979