### PR TITLE
[Streaming] Add `StreamCompletion` id field

### DIFF
--- a/storey/dtypes.py
+++ b/storey/dtypes.py
@@ -156,6 +156,10 @@ class StreamCompletion:
         error_info = f", error={self.error!r}" if self.error else ""
         return f"StreamCompletion(streaming_step={self.streaming_step!r}, event_id={event_id!r}{error_info})"
 
+    @property
+    def id(self):
+        return self.original_event.id if self.original_event else None
+
 
 class WindowBase:
     def __init__(self, window, period, window_str):

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -311,7 +311,7 @@ class Flow:
     @staticmethod
     def _event_string(event):
         result = "Event("
-        if event.id:
+        if getattr(event, "id", None):
             result += f"id={event.id}, "
         if getattr(event, "key", None):
             result += f"key={event.key}, "


### PR DESCRIPTION
Small fix for a logging problem. when the event is from the kind of `StreamCompletion` it's missing id field