### PR TITLE
Fix `ConcurrentExecution` passing raw generator to downstream steps

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -63,6 +63,16 @@ def _is_generator(obj) -> bool:
     return inspect.isgenerator(obj) or inspect.isasyncgen(obj)
 
 
+def _is_awaitable_coroutine(obj) -> bool:
+    """Check if an object is a coroutine that should be awaited.
+
+    Generators must be excluded because in Python <=3.11,
+    asyncio.iscoroutine() can return True for plain generators
+    due to the legacy _iscoroutine_typecache (removed in 3.12).
+    """
+    return not _is_generator(obj) and asyncio.iscoroutine(obj)
+
+
 def is_batched_event(event) -> bool:
     return (
         not isinstance(event, StreamCompletion)
@@ -1340,7 +1350,7 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
         else:
             result = self._event_processor(*args)
 
-        if not _is_generator(result) and asyncio.iscoroutine(result):
+        if _is_awaitable_coroutine(result):
             result = await result
 
         if self._full_event:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1271,7 +1271,7 @@ class _ConcurrentJobExecution(Flow):
                     await self._worker_awaitable
 
 
-class ConcurrentExecution(_ConcurrentJobExecution):
+class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
     """
     Inherit this class and override `process_event()` to process events concurrently.
 
@@ -1340,7 +1340,7 @@ class ConcurrentExecution(_ConcurrentJobExecution):
         else:
             result = self._event_processor(*args)
 
-        if asyncio.iscoroutine(result):
+        if not _is_generator(result) and asyncio.iscoroutine(result):
             result = await result
 
         if self._full_event:
@@ -1350,7 +1350,10 @@ class ConcurrentExecution(_ConcurrentJobExecution):
             return event
 
     async def _handle_completed(self, event, response):
-        await self._do_downstream(response)
+        if not self._full_event and _is_generator(response.body):
+            await self._emit_streaming_chunks(response, response.body)
+        else:
+            await self._do_downstream(response)
 
 
 class SendToHttp(_ConcurrentJobExecution):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -23,6 +23,7 @@ from storey import (
     Choice,
     Collector,
     Complete,
+    ConcurrentExecution,
     Flow,
     Map,
     MapClass,
@@ -1957,3 +1958,87 @@ class TestVerboseLoggingWithStreamCompletion:
         all_log_messages = " ".join(str(log[1]) for log in logger.logs)
         # The logs should contain references to the step names showing flow progression
         assert "StreamingMap" in all_log_messages or "Collector" in all_log_messages
+
+
+class TestConcurrentExecutionStreaming:
+    """Tests for ConcurrentExecution streaming support (ML-12178).
+
+    ConcurrentExecution should handle async generator process_event functions
+    the same way Map handles generator functions -- by emitting streaming chunks
+    and StreamCompletion, so that a downstream Collector can aggregate them.
+    """
+
+    @pytest.mark.parametrize("use_async_generator", [False, True], ids=["sync_gen", "async_gen"])
+    def test_concurrent_execution_generator_with_collector(self, use_async_generator):
+        """Reproducer for ML-12178: ConcurrentExecution with generator -> Collector -> downstream.
+
+        When process_event is a generator (sync or async), ConcurrentExecution should emit
+        streaming chunks so the Collector can aggregate them into a list. Without
+        the fix, the Collector receives a raw generator object instead.
+        """
+
+        if use_async_generator:
+
+            async def stream_chunks(event):
+                for i in range(3):
+                    yield f"{event}_chunk_{i}"
+
+        else:
+
+            def stream_chunks(event):
+                for i in range(3):
+                    yield f"{event}_chunk_{i}"
+
+        controller = build_flow(
+            [
+                SyncEmitSource(),
+                ConcurrentExecution(stream_chunks),
+                Collector(),
+                Reduce([], lambda acc, x: acc + [x]),
+            ]
+        ).run()
+
+        try:
+            controller.emit("test")
+        finally:
+            controller.terminate()
+            result = controller.await_termination()
+
+        assert len(result) == 1
+        collected = result[0]
+        assert isinstance(
+            collected, list
+        ), f"Expected collected chunks as a list, got {type(collected).__name__}: {collected}"
+        assert collected == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
+
+    def test_concurrent_execution_generator_then_streaming_step(self):
+        """Full ML-12178 scenario: ConcurrentExecution -> Collector -> second streaming step.
+
+        The second streaming step should receive the collected list, not a generator object.
+        """
+
+        async def first_stream(event):
+            for i in range(2):
+                yield f"{event}_{i}"
+
+        def second_stream(collected):
+            for item in collected:
+                yield f"re_{item}"
+
+        controller = build_flow(
+            [
+                SyncEmitSource(),
+                ConcurrentExecution(first_stream),
+                Collector(),
+                Map(second_stream),
+                Reduce([], lambda acc, x: acc + [x]),
+            ]
+        ).run()
+
+        try:
+            controller.emit("test")
+        finally:
+            controller.terminate()
+            result = controller.await_termination()
+
+        assert result == ["re_test_0", "re_test_1"]


### PR DESCRIPTION
[ML-12178](https://iguazio.atlassian.net/browse/ML-12178)

When `process_event` was a generator function (sync or async), the yielded values were not streamed individually — the generator object itself was forwarded as the event body. This broke graphs like `ConcurrentExecution` -> `Collector` -> ...

Added streaming support to `ConcurrentExecution` (via `_StreamingStepMixin`), so generator results are detected and emitted as proper streaming chunks — the same way `Map` already handles them.

Also added a guard against a Python <=3.11 quirk where `asyncio.iscoroutine()` can match plain generators, which would cause a `TypeError` on `await`.

[ML-12178]: https://iguazio.atlassian.net/browse/ML-12178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ