### PR TITLE
[Stream] Avoid blocking event loop with non-asyncio generator

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -655,7 +655,7 @@ class _StreamingStepMixin:
         async def gen_to_async_gen(sync_gen):
             loop = asyncio.get_running_loop()
             while True:
-                # Run next() in executor so blocking calls (e.g., time.sleep) don't block the event loop
+                # Run next() in executor so blocking calls don't block the event loop
                 item = await loop.run_in_executor(None, _next_or_sentinel, sync_gen)
                 if item is _sentinel:
                     break

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -644,8 +644,21 @@ class _StreamingStepMixin:
         """
         self._validate_not_already_streaming(event)
 
+        _sentinel = object()
+
+        def _next_or_sentinel(gen):
+            try:
+                return next(gen)
+            except StopIteration:
+                return _sentinel
+
         async def gen_to_async_gen(sync_gen):
-            for item in sync_gen:
+            loop = asyncio.get_running_loop()
+            while True:
+                # Run next() in executor so blocking calls (e.g., time.sleep) don't block the event loop
+                item = await loop.run_in_executor(None, _next_or_sentinel, sync_gen)
+                if item is _sentinel:
+                    break
                 yield item
 
         # If needed, wrap sync generator as async to unify iteration

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -14,6 +14,7 @@
 #
 import asyncio
 import inspect
+import time
 from typing import AsyncGenerator, Generator, Optional
 
 import pytest
@@ -2042,3 +2043,117 @@ class TestConcurrentExecutionStreaming:
             result = controller.await_termination()
 
         assert result == ["re_test_0", "re_test_1"]
+
+
+class TestStreamingSyncGeneratorNonBlocking:
+    """Tests that sync generators with blocking calls don't block the event loop.
+
+    When a sync generator contains blocking operations like time.sleep(), these should
+    be executed in a thread pool so they don't block the asyncio event loop.
+    """
+
+    def test_sync_generator_with_sleep_does_not_block_event_loop(self):
+        """Test that a sync generator with time.sleep() doesn't block the event loop.
+
+        This verifies that the gen_to_async_gen wrapper in _emit_streaming_chunks
+        runs the sync generator's next() calls in an executor, allowing other
+        async tasks to proceed while the generator sleeps.
+        """
+
+        async def _test():
+            sleep_duration = 0.1
+            num_chunks = 3
+            concurrent_ticks = []
+
+            def slow_generator(x):
+                for i in range(num_chunks):
+                    time.sleep(sleep_duration)
+                    yield f"{x}_chunk_{i}"
+
+            async def concurrent_task():
+                """Task that runs concurrently with the streaming generator."""
+                tick_interval = sleep_duration / 3
+                for i in range(num_chunks * 4):
+                    concurrent_ticks.append(i)
+                    await asyncio.sleep(tick_interval)
+
+            source = AsyncEmitSource()
+            streaming_map = Map(slow_generator)
+            reducer = Reduce([], lambda acc, x: acc + [x])
+
+            source.to(streaming_map).to(reducer)
+
+            controller = source.run()
+
+            # Start concurrent task alongside streaming
+            concurrent = asyncio.create_task(concurrent_task())
+
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
+                result = await controller.await_termination()
+
+            await concurrent
+
+            # Verify streaming worked correctly
+            assert result == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
+
+            # Verify concurrent task made progress during the blocking sleeps.
+            # If time.sleep blocked the event loop, concurrent_ticks would be empty
+            # or have very few entries. With proper async handling, concurrent_task
+            # should have multiple ticks during each sleep.
+            assert len(concurrent_ticks) >= num_chunks * 2, (
+                f"Expected concurrent task to make progress during blocking sleeps. "
+                f"Got {len(concurrent_ticks)} ticks, expected at least {num_chunks * 2}. "
+                "This suggests time.sleep() blocked the event loop."
+            )
+
+        asyncio.run(_test())
+
+    def test_sync_generator_with_sleep_through_collector(self):
+        """Test sync generator with time.sleep through Collector aggregation."""
+
+        def slow_generator(x):
+            for i in range(3):
+                time.sleep(0.05)
+                yield f"{x}_chunk_{i}"
+
+        controller = build_flow(
+            [
+                SyncEmitSource(),
+                Map(slow_generator),
+                Collector(),
+                Reduce([], lambda acc, x: acc + [x]),
+            ]
+        ).run()
+
+        controller.emit("test")
+        controller.terminate()
+        result = controller.await_termination()
+
+        assert len(result) == 1
+        assert result[0] == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
+
+    def test_mapclass_sync_generator_with_sleep(self):
+        """Test MapClass with sync generator that uses time.sleep."""
+
+        class SlowStreamingMapper(MapClass):
+            def do(self, x):
+                for i in range(3):
+                    time.sleep(0.05)
+                    yield f"{x}_chunk_{i}"
+
+        controller = build_flow(
+            [
+                SyncEmitSource(),
+                SlowStreamingMapper(),
+                Reduce([], lambda acc, x: acc + [x]),
+            ]
+        ).run()
+
+        controller.emit("test")
+        controller.terminate()
+        result = controller.await_termination()
+
+        assert result == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2061,9 +2061,10 @@ class TestStreamingSyncGeneratorNonBlocking:
         """
 
         async def _test():
-            sleep_duration = 0.1
+            sleep_duration = 0.15
             num_chunks = 3
             concurrent_ticks = []
+            streaming_done = asyncio.Event()
 
             def slow_generator(x):
                 for i in range(num_chunks):
@@ -2071,10 +2072,14 @@ class TestStreamingSyncGeneratorNonBlocking:
                     yield f"{x}_chunk_{i}"
 
             async def concurrent_task():
-                """Task that runs concurrently with the streaming generator."""
-                tick_interval = sleep_duration / 3
-                for i in range(num_chunks * 4):
-                    concurrent_ticks.append(i)
+                """Task that runs concurrently with the streaming generator.
+
+                Keeps ticking until streaming is done. If the event loop is blocked,
+                this task won't get a chance to run and concurrent_ticks will be empty.
+                """
+                tick_interval = sleep_duration / 4
+                while not streaming_done.is_set():
+                    concurrent_ticks.append(time.time())
                     await asyncio.sleep(tick_interval)
 
             source = AsyncEmitSource()
@@ -2085,7 +2090,7 @@ class TestStreamingSyncGeneratorNonBlocking:
 
             controller = source.run()
 
-            # Start concurrent task alongside streaming
+            # Start concurrent task BEFORE emitting
             concurrent = asyncio.create_task(concurrent_task())
 
             try:
@@ -2094,15 +2099,18 @@ class TestStreamingSyncGeneratorNonBlocking:
                 await controller.terminate()
                 result = await controller.await_termination()
 
+            # Signal concurrent task to stop and wait for it
+            streaming_done.set()
             await concurrent
 
             # Verify streaming worked correctly
             assert result == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
 
             # Verify concurrent task made progress during the blocking sleeps.
-            # If time.sleep blocked the event loop, concurrent_ticks would be empty
-            # or have very few entries. With proper async handling, concurrent_task
-            # should have multiple ticks during each sleep.
+            # Total sleep time is ~0.45s (3 chunks * 0.15s each).
+            # If event loop was NOT blocked, concurrent_task should tick multiple times
+            # during each sleep (~4 ticks per sleep = ~12 ticks total).
+            # If event loop WAS blocked, concurrent_ticks would have 0-3 entries.
             assert len(concurrent_ticks) >= num_chunks * 2, (
                 f"Expected concurrent task to make progress during blocking sleeps. "
                 f"Got {len(concurrent_ticks)} ticks, expected at least {num_chunks * 2}. "


### PR DESCRIPTION
As part of streaming, we allow the user to provide a non-asyncio generator and handle the transformation ourselves.
To prevent blocking the asyncio event loop, the generator should be executed on a separate thread, as introduced in this PR.

[ML-12203](https://iguazio.atlassian.net/browse/ML-12203)

[ML-12203]: https://iguazio.atlassian.net/browse/ML-12203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ