### PR TITLE
[Stream] Fix Wrap process-based streaming results in _StreamingResult

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -2198,7 +2198,14 @@ class RunnableExecutor:
                         executor, _streaming_run_wrapper, runnable, input, event.path, origin_runnable_name, queue
                     )
                 future = loop.create_future()
-                future.set_result(_async_read_streaming_queue(queue))
+                timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+                future.set_result(
+                    _StreamingResult(
+                        origin_runnable_name or runnable.name,
+                        _async_read_streaming_queue(queue),
+                        timestamp,
+                    )
+                )
             else:
                 # Use appropriate run function based on mechanism
                 if execution_mechanism == ParallelExecutionMechanisms.dedicated_process:


### PR DESCRIPTION
ticket: https://iguazio.atlassian.net/browse/ML-12205
**Problem**
When using process_pool or dedicated_process execution mechanisms with streaming models, selecting multiple streaming runnables produces an incorrect error:

`AttributeError: 'async_generator' object has no attribute 'runnable_name'
Instead of the expected:
StreamingError: Streaming is not supported when multiple runnables are selected.`

**Root Cause**
In RunnableExecutor.run_executor(), process-based streaming returns a raw async generator from _async_read_streaming_queue(), while other mechanisms (naive, asyncio, thread_pool) wrap their results in _StreamingResult. This inconsistency causes the error handling code in ParallelExecution._do() to fail when accessing result.runnable_name.

**Fix**
Wrap the async generator in _StreamingResult for process-based streaming, consistent with other execution mechanisms:
future.set_result(
    _StreamingResult(
        origin_runnable_name or runnable.name,
        _async_read_streaming_queue(queue),
        timestamp,
    )
)
 