### PR TITLE
Fix event loop blocking by sync generators in streaming steps

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -73,6 +73,20 @@ def _is_awaitable_coroutine(obj) -> bool:
     return not _is_generator(obj) and asyncio.iscoroutine(obj)
 
 
+_sync_gen_sentinel = object()
+
+
+async def _gen_to_async_gen(sync_gen):
+    """Wrap a synchronous generator as an async generator, offloading each
+    next() call to a thread so it doesn't block the event loop."""
+    loop = asyncio.get_running_loop()
+    while True:
+        item = await loop.run_in_executor(None, next, sync_gen, _sync_gen_sentinel)
+        if item is _sync_gen_sentinel:
+            break
+        yield item
+
+
 def is_batched_event(event) -> bool:
     return (
         not isinstance(event, StreamCompletion)
@@ -644,12 +658,8 @@ class _StreamingStepMixin:
         """
         self._validate_not_already_streaming(event)
 
-        async def gen_to_async_gen(sync_gen):
-            for item in sync_gen:
-                yield item
-
         # If needed, wrap sync generator as async to unify iteration
-        async_gen = gen_to_async_gen(generator) if inspect.isgenerator(generator) else generator
+        async_gen = _gen_to_async_gen(generator) if inspect.isgenerator(generator) else generator
 
         chunk_id = 0
         generator_error = None

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -14,6 +14,7 @@
 #
 import asyncio
 import inspect
+import time
 from typing import AsyncGenerator, Generator, Optional
 
 import pytest
@@ -2083,3 +2084,52 @@ class TestConcurrentExecutionStreaming:
             result = controller.await_termination()
 
         assert result == ["re_test_0", "re_test_1"]
+
+
+class TestSyncGeneratorEventLoopBlocking:
+    def test_sync_generator_does_not_block_event_loop(self):
+        """A sync generator with time.sleep() must not starve the event loop.
+
+        Reproduces ML-12203: when em=naive or em=thread_pool, a blocking sync
+        generator in _emit_streaming_chunks prevents the event loop from flushing
+        HTTP chunks, causing them to be concatenated.
+        """
+
+        async def _test():
+            sleep_duration = 0.15
+            num_chunks = 3
+            concurrent_ticks = []
+            streaming_done = asyncio.Event()
+
+            def slow_generator(x):
+                for i in range(num_chunks):
+                    time.sleep(sleep_duration)
+                    yield f"{x}_chunk_{i}"
+
+            async def concurrent_task():
+                tick_interval = sleep_duration / 4
+                while not streaming_done.is_set():
+                    concurrent_ticks.append(time.monotonic())
+                    await asyncio.sleep(tick_interval)
+
+            source = AsyncEmitSource()
+            source.to(Map(slow_generator)).to(Reduce([], lambda acc, x: acc + [x]))
+            controller = source.run()
+
+            concurrent = asyncio.create_task(concurrent_task())
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
+                result = await controller.await_termination()
+
+            streaming_done.set()
+            await concurrent
+
+            assert result == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
+            assert len(concurrent_ticks) >= num_chunks * 2, (
+                f"Event loop was blocked: only {len(concurrent_ticks)} ticks "
+                f"during {sleep_duration * num_chunks:.2f}s of generator sleeps"
+            )
+
+        asyncio.run(_test())


### PR DESCRIPTION
Supersedes #625.

Fixes [ML-12203](https://iguazio.atlassian.net/browse/ML-12203).

Offload synchronous generator iteration to a thread via `run_in_executor` in `_emit_streaming_chunks`, preventing blocking calls (e.g. `time.sleep`) from starving the event loop and causing HTTP chunk concatenation. Add a regression test that verifies concurrent event loop progress during slow sync generator execution.

[ML-12203]: https://iguazio.atlassian.net/browse/ML-12203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ