### PR TITLE
Fix concurrent streaming in `ConcurrentExecution`

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -76,6 +76,25 @@ def _is_awaitable_coroutine(obj) -> bool:
 _sync_gen_sentinel = object()
 
 
+class _GeneratorDone:
+    """Sentinel placed on a streaming queue when the generator is exhausted."""
+
+    __slots__ = ("error",)
+
+    def __init__(self, error=None):
+        self.error = error
+
+
+class _StreamingQueue:
+    """Wrapper around an asyncio.Queue fed by a background generator consumer."""
+
+    __slots__ = ("queue", "task")
+
+    def __init__(self, queue, task):
+        self.queue = queue
+        self.task = task
+
+
 async def _gen_to_async_gen(sync_gen):
     """Wrap a synchronous generator as an async generator, offloading each
     next() call to a thread so it doesn't block the event loop."""
@@ -1297,10 +1316,15 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
 
     :param process_event: Function that will be run on each event
 
-    :param concurrency_mechanism: One of:
-      * "asyncio" (default) – for I/O implemented using asyncio
-      * "threading" – for blocking I/O
-      * "multiprocessing" – for processing-intensive tasks
+    :param concurrency_mechanism: Execution mechanism. One of the ``ParallelExecutionMechanisms``
+      values, or a legacy name for backward compatibility:
+
+      * ``"asyncio"`` (default) – for I/O implemented using asyncio
+      * ``"thread_pool"`` (or legacy ``"threading"``) – for blocking I/O
+      * ``"process_pool"`` (or legacy ``"multiprocessing"``) – for processing-intensive tasks
+      * ``"dedicated_process"`` – like process_pool with a single dedicated worker
+      * ``"shared_executor"`` – use an externally supplied executor
+      * ``"naive"`` – run synchronously on the event loop (for trivial work)
 
     :param max_in_flight: Maximum number of events to be processed at a time (default 8)
     :param retries: Maximum number of retries per event (default 0)
@@ -1312,7 +1336,10 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
         or only the payload (when False). Defaults to False.
     """
 
-    _supported_concurrency_mechanisms = ["asyncio", "threading", "multiprocessing"]
+    _LEGACY_MECHANISM_MAP = {
+        "threading": "thread_pool",
+        "multiprocessing": "process_pool",
+    }
 
     def __init__(
         self,
@@ -1323,40 +1350,105 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
     ):
         super().__init__(**kwargs)
 
-        if concurrency_mechanism == "multiprocessing" and kwargs.get("full_event"):
+        self._event_processor = event_processor
+        self._pass_context = pass_context
+
+        # Resolve mechanism: map legacy names, default to asyncio
+        original_mechanism = concurrency_mechanism
+        if concurrency_mechanism is None:
+            concurrency_mechanism = ParallelExecutionMechanisms.asyncio
+        elif concurrency_mechanism in self._LEGACY_MECHANISM_MAP:
+            concurrency_mechanism = self._LEGACY_MECHANISM_MAP[concurrency_mechanism]
+        else:
+            ParallelExecutionMechanisms.validate(concurrency_mechanism)
+
+        self._concurrency_mechanism = ParallelExecutionMechanisms(concurrency_mechanism)
+
+        # Use original name in error messages so legacy callers see what they passed
+        mechanism_label = original_mechanism or "asyncio"
+
+        if self._concurrency_mechanism in ParallelExecutionMechanisms.process() and kwargs.get("full_event"):
             raise ValueError(
-                'concurrency_mechanism="multiprocessing" may not be used in conjunction with full_event=True'
+                f'concurrency_mechanism="{mechanism_label}" may not be used ' "in conjunction with full_event=True"
             )
 
-        self._event_processor = event_processor
-
-        if concurrency_mechanism and concurrency_mechanism not in self._supported_concurrency_mechanisms:
-            raise ValueError(f"Concurrency mechanism '{concurrency_mechanism}' is not supported")
-
-        if concurrency_mechanism == "multiprocessing" and pass_context:
+        if self._concurrency_mechanism in ParallelExecutionMechanisms.process() and pass_context:
             try:
                 pickle.dumps(self.context)
             except Exception as ex:
                 raise ValueError(
-                    'When concurrency_mechanism="multiprocessing" is used in conjunction with '
+                    f'When concurrency_mechanism="{mechanism_label}" is used in conjunction with '
                     "pass_context=True, context must be serializable"
                 ) from ex
 
         self._executor = None
-        if concurrency_mechanism == "threading":
-            self._executor = ThreadPoolExecutor(max_workers=self.max_in_flight or self._DEFAULT_MAX_IN_FLIGHT)
-        elif concurrency_mechanism == "multiprocessing":
-            self._executor = ProcessPoolExecutor(max_workers=self.max_in_flight or self._DEFAULT_MAX_IN_FLIGHT)
+        self._mp_manager = None
+        self._is_generator_fn = inspect.isgeneratorfunction(event_processor)
+        pool_size = self.max_in_flight or self._DEFAULT_MAX_IN_FLIGHT
+        if self._concurrency_mechanism == ParallelExecutionMechanisms.thread_pool:
+            self._executor = ThreadPoolExecutor(max_workers=pool_size)
+        elif self._concurrency_mechanism == ParallelExecutionMechanisms.process_pool:
+            self._executor = ProcessPoolExecutor(max_workers=pool_size)
+        elif self._concurrency_mechanism == ParallelExecutionMechanisms.dedicated_process:
+            self._executor = ProcessPoolExecutor(max_workers=1)
 
-        self._pass_context = pass_context
+    async def _iterate_generator(self, generator, queue):
+        """Background task: consume a generator into an asyncio.Queue.
+
+        For async generators, iterates directly.  For sync generators,
+        dispatches each next() via run_in_executor to avoid blocking the
+        event loop (uses self._executor when set, otherwise the default
+        thread pool).
+        """
+        error = None
+        try:
+            if inspect.isasyncgen(generator):
+                async for chunk in generator:
+                    await queue.put(chunk)
+            else:
+                loop = asyncio.get_running_loop()
+                while True:
+                    chunk = await loop.run_in_executor(self._executor, next, generator, _sync_gen_sentinel)
+                    if chunk is _sync_gen_sentinel:
+                        break
+                    await queue.put(chunk)
+        except Exception as e:
+            error = e
+        await queue.put(_GeneratorDone(error))
+
+    def _get_mp_manager(self):
+        if self._mp_manager is None:
+            self._mp_manager = multiprocessing.get_context("spawn").Manager()
+        return self._mp_manager
 
     async def _process_event(self, event):
         args = [event if self._full_event else event.body]
 
         if self._pass_context:
             args.append(self.context)
+
+        loop = asyncio.get_running_loop()
+
+        # Process-based mechanisms with generator functions: use IPC pattern
+        # (run event processor + iterate generator in subprocess, stream chunks
+        # via multiprocessing.Queue).
+        if self._is_generator_fn and self._concurrency_mechanism in ParallelExecutionMechanisms.process():
+            mp_queue = self._get_mp_manager().Queue()
+            loop.run_in_executor(
+                self._executor,
+                _concurrent_streaming_run_in_subprocess,
+                self._event_processor,
+                args,
+                mp_queue,
+            )
+            ipc_gen = _async_read_streaming_queue(mp_queue)
+            async_queue = asyncio.Queue()
+            task = loop.create_task(self._iterate_generator(ipc_gen, async_queue))
+            event.body = _StreamingQueue(async_queue, task)
+            return event
+
         if self._executor:
-            result = await asyncio.get_running_loop().run_in_executor(self._executor, self._event_processor, *args)
+            result = await loop.run_in_executor(self._executor, self._event_processor, *args)
         else:
             result = self._event_processor(*args)
 
@@ -1365,12 +1457,46 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
 
         if self._full_event:
             return result
+
+        if _is_generator(result):
+            async_queue = asyncio.Queue()
+            task = loop.create_task(self._iterate_generator(result, async_queue))
+            event.body = _StreamingQueue(async_queue, task)
         else:
             event.body = result
-            return event
+        return event
+
+    async def _emit_streaming_from_queue(self, event, queue):
+        """Read chunks from an asyncio.Queue and emit them downstream.
+
+        Mirrors _emit_streaming_chunks but reads from a queue fed by a
+        background _iterate_generator task rather than iterating a
+        generator directly.
+        """
+        self._validate_not_already_streaming(event)
+        chunk_id = 0
+        generator_error = None
+
+        while True:
+            item = await queue.get()
+            if isinstance(item, _GeneratorDone):
+                generator_error = item.error
+                break
+            chunk_event = self._user_fn_output_to_event(event, item)
+            chunk_event.streaming_step = self.name
+            chunk_event.chunk_id = chunk_id
+            await self._do_downstream(chunk_event)
+            chunk_id += 1
+
+        error_str = f"{type(generator_error).__name__}: {generator_error}" if generator_error else None
+        await self._do_downstream(StreamCompletion(self.name, event, error=error_str))
 
     async def _handle_completed(self, event, response):
-        if not self._full_event and _is_generator(response.body):
+        if isinstance(response.body, _StreamingQueue):
+            streaming_queue = response.body
+            await self._emit_streaming_from_queue(response, streaming_queue.queue)
+            await streaming_queue.task
+        elif not self._full_event and _is_generator(response.body):
             await self._emit_streaming_chunks(response, response.body)
         else:
             await self._do_downstream(response)
@@ -2025,6 +2151,23 @@ def _set_global(sval):
 def _static_run(*args, **kwargs):
     global _sval
     return _sval._run(*args, **kwargs)
+
+
+def _concurrent_streaming_run_in_subprocess(event_processor, args, queue):
+    """Run an event processor in a subprocess and stream generator chunks via queue.
+
+    Used by ConcurrentExecution for process-based mechanisms when the event
+    processor is a generator function.  Follows the same (msg_type, payload)
+    protocol as _streaming_run_wrapper so _async_read_streaming_queue can
+    consume the results.
+    """
+    try:
+        result = event_processor(*args)
+        for chunk in result:
+            queue.put(("chunk", chunk))
+        queue.put(("done", None))
+    except Exception as e:
+        queue.put(("error", (type(e).__name__, str(e), traceback.format_exc())))
 
 
 def _streaming_run_wrapper(

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1441,9 +1441,9 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
                 args,
                 mp_queue,
             )
-            ipc_gen = _async_read_streaming_queue(mp_queue)
+            subprocess_chunks = _async_read_streaming_queue(mp_queue)
             async_queue = asyncio.Queue()
-            task = loop.create_task(self._iterate_generator(ipc_gen, async_queue))
+            task = loop.create_task(self._iterate_generator(subprocess_chunks, async_queue))
             event.body = _StreamingQueue(async_queue, task)
             return event
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -2103,39 +2103,24 @@ class TestConcurrentExecutionStreaming:
     # -- ML-12378 concurrency tests ----------------------------------------
     # Verify that streaming generators run concurrently (not serially) when
     # max_in_flight > 1, across execution mechanisms.
-    #
-    # async gen (asyncio): deterministic active-counter check with
-    #   ``await asyncio.sleep(0)`` as yield points.
-    # sync gen (thread_pool, process_pool, naive): time-based check using
-    #   ``time.sleep`` to simulate blocking work.  For naive (synchronous
-    #   by design) only correctness is asserted.
-    #
-    # NOTE: a future robustness improvement is to add an explicit
-    # ``await asyncio.sleep(0)`` inside ``_iterate_generator`` itself so
-    # that even async generators with no internal await points get fair
-    # scheduling.
 
-    _ML12378_NUM_CHUNKS = 3
-    _ML12378_NUM_EVENTS = 4
-
-    def _assert_streaming_results(self, result):
+    def _assert_streaming_results(self, result, n_events, n_chunks):
         """Check all events were collected with the correct chunks (order-independent)."""
-        n, k = self._ML12378_NUM_EVENTS, self._ML12378_NUM_CHUNKS
-        assert len(result) == n, f"Expected {n} collected events, got {len(result)}"
-        expected = {tuple(f"event_{i}_chunk_{j}" for j in range(k)) for i in range(n)}
+        assert len(result) == n_events, f"Expected {n_events} collected events, got {len(result)}"
+        expected = {tuple(f"event_{i}_chunk_{j}" for j in range(n_chunks)) for i in range(n_events)}
         actual = {tuple(collected) for collected in result}
         assert actual == expected, f"Unexpected results: {actual} != {expected}"
 
     def test_concurrent_streaming_asyncio_async_gen(self):
-        """ML-12378: default (asyncio) mechanism + async generator.
+        """Default (asyncio) mechanism + async generator.
 
         Tracks max simultaneously-active generators.  ``await asyncio.sleep(0)``
         between yields simulates realistic I/O and gives the event loop a
         chance to schedule other generator tasks.
         """
 
-        n_chunks = self._ML12378_NUM_CHUNKS
-        n_events = self._ML12378_NUM_EVENTS
+        n_chunks = 3
+        n_events = 4
 
         async def _run():
             active = 0
@@ -2168,10 +2153,10 @@ class TestConcurrentExecutionStreaming:
             await controller.terminate()
             result = await controller.await_termination()
 
-            self._assert_streaming_results(result)
+            self._assert_streaming_results(result, n_events, n_chunks)
             assert max_active > 1, (
                 f"Generators not concurrent: max active was {max_active}, "
-                f"expected > 1 with max_in_flight={n_events} (ML-12378)"
+                f"expected > 1 with max_in_flight={n_events}"
             )
 
         asyncio.run(_run())
@@ -2188,7 +2173,7 @@ class TestConcurrentExecutionStreaming:
         ],
     )
     def test_concurrent_streaming_sync_gen(self, mechanism, expect_concurrent):
-        """ML-12378: sync generator across execution mechanisms.
+        """Sync generator across execution mechanisms.
 
         Uses a module-level function with ``time.sleep`` per event to
         simulate blocking work.  For mechanisms that support concurrency the
@@ -2196,7 +2181,7 @@ class TestConcurrentExecutionStreaming:
         and dedicated_process (single worker) only correctness is checked.
         """
 
-        n_events = self._ML12378_NUM_EVENTS
+        n_events = 4
         chunk_delay = _SYNC_STREAMING_DELAY
 
         async def _run():
@@ -2221,13 +2206,12 @@ class TestConcurrentExecutionStreaming:
             result = await controller.await_termination()
             elapsed = time.monotonic() - start
 
-            self._assert_streaming_results(result)
+            self._assert_streaming_results(result, n_events, 3)
 
             if expect_concurrent:
                 serial_duration = chunk_delay * n_events
                 assert elapsed < serial_duration * 0.75, (
-                    f"{mechanism} streaming serialized: {elapsed:.2f}s "
-                    f"vs serial estimate {serial_duration:.2f}s (ML-12378)"
+                    f"{mechanism} streaming serialized: {elapsed:.2f}s " f"vs serial estimate {serial_duration:.2f}s"
                 )
 
         asyncio.run(_run())

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -41,6 +41,21 @@ from storey.dtypes import Event, StreamChunk, StreamCompletion
 from storey.flow import _is_generator
 from tests.helpers import MockContext, MockLogger
 
+_SYNC_STREAMING_DELAY = 1.0
+
+
+def _sync_streaming_fn(event):
+    """Module-level sync streaming function for concurrency tests (must be picklable for process_pool)."""
+    time.sleep(_SYNC_STREAMING_DELAY)
+    for i in range(3):
+        yield f"{event}_chunk_{i}"
+
+
+def _sync_error_streaming_fn(event):
+    """Module-level sync generator that yields one chunk then raises (must be picklable for process_pool)."""
+    yield f"{event}_chunk_0"
+    raise ValueError("sync generator error mid-stream")
+
 
 class StreamingRunnable(ParallelExecutionRunnable):
     """A streaming runnable that yields 3 chunks for testing."""
@@ -2084,6 +2099,270 @@ class TestConcurrentExecutionStreaming:
             result = controller.await_termination()
 
         assert result == ["re_test_0", "re_test_1"]
+
+    # -- ML-12378 concurrency tests ----------------------------------------
+    # Verify that streaming generators run concurrently (not serially) when
+    # max_in_flight > 1, across execution mechanisms.
+    #
+    # async gen (asyncio): deterministic active-counter check with
+    #   ``await asyncio.sleep(0)`` as yield points.
+    # sync gen (thread_pool, process_pool, naive): time-based check using
+    #   ``time.sleep`` to simulate blocking work.  For naive (synchronous
+    #   by design) only correctness is asserted.
+    #
+    # NOTE: a future robustness improvement is to add an explicit
+    # ``await asyncio.sleep(0)`` inside ``_iterate_generator`` itself so
+    # that even async generators with no internal await points get fair
+    # scheduling.
+
+    _ML12378_NUM_CHUNKS = 3
+    _ML12378_NUM_EVENTS = 4
+
+    def _assert_streaming_results(self, result):
+        """Check all events were collected with the correct chunks (order-independent)."""
+        n, k = self._ML12378_NUM_EVENTS, self._ML12378_NUM_CHUNKS
+        assert len(result) == n, f"Expected {n} collected events, got {len(result)}"
+        expected = {tuple(f"event_{i}_chunk_{j}" for j in range(k)) for i in range(n)}
+        actual = {tuple(collected) for collected in result}
+        assert actual == expected, f"Unexpected results: {actual} != {expected}"
+
+    def test_concurrent_streaming_asyncio_async_gen(self):
+        """ML-12378: default (asyncio) mechanism + async generator.
+
+        Tracks max simultaneously-active generators.  ``await asyncio.sleep(0)``
+        between yields simulates realistic I/O and gives the event loop a
+        chance to schedule other generator tasks.
+        """
+
+        n_chunks = self._ML12378_NUM_CHUNKS
+        n_events = self._ML12378_NUM_EVENTS
+
+        async def _run():
+            active = 0
+            max_active = 0
+
+            async def stream_chunks(event):
+                nonlocal active, max_active
+                active += 1
+                if active > max_active:
+                    max_active = active
+                try:
+                    for i in range(n_chunks):
+                        await asyncio.sleep(0)
+                        yield f"{event}_chunk_{i}"
+                finally:
+                    active -= 1
+
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    ConcurrentExecution(stream_chunks, max_in_flight=n_events),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
+
+            for i in range(n_events):
+                await controller.emit(f"event_{i}")
+
+            await controller.terminate()
+            result = await controller.await_termination()
+
+            self._assert_streaming_results(result)
+            assert max_active > 1, (
+                f"Generators not concurrent: max active was {max_active}, "
+                f"expected > 1 with max_in_flight={n_events} (ML-12378)"
+            )
+
+        asyncio.run(_run())
+
+    @pytest.mark.parametrize(
+        "mechanism, expect_concurrent",
+        [
+            ("thread_pool", True),
+            ("process_pool", True),
+            ("dedicated_process", False),  # single worker — generators serialize
+            # shared_executor omitted: requires an executor= parameter not yet
+            # supported by ConcurrentExecution.
+            ("naive", False),
+        ],
+    )
+    def test_concurrent_streaming_sync_gen(self, mechanism, expect_concurrent):
+        """ML-12378: sync generator across execution mechanisms.
+
+        Uses a module-level function with ``time.sleep`` per event to
+        simulate blocking work.  For mechanisms that support concurrency the
+        total elapsed time must be well below the serial estimate.  For naive
+        and dedicated_process (single worker) only correctness is checked.
+        """
+
+        n_events = self._ML12378_NUM_EVENTS
+        chunk_delay = _SYNC_STREAMING_DELAY
+
+        async def _run():
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    ConcurrentExecution(
+                        _sync_streaming_fn,
+                        concurrency_mechanism=mechanism,
+                        max_in_flight=n_events,
+                    ),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
+
+            start = time.monotonic()
+            for i in range(n_events):
+                await controller.emit(f"event_{i}")
+
+            await controller.terminate()
+            result = await controller.await_termination()
+            elapsed = time.monotonic() - start
+
+            self._assert_streaming_results(result)
+
+            if expect_concurrent:
+                serial_duration = chunk_delay * n_events
+                assert elapsed < serial_duration * 0.75, (
+                    f"{mechanism} streaming serialized: {elapsed:.2f}s "
+                    f"vs serial estimate {serial_duration:.2f}s (ML-12378)"
+                )
+
+        asyncio.run(_run())
+
+    # -- Error handling tests --------------------------------------------------
+    # Verify that generator errors in ConcurrentExecution are propagated
+    # correctly through _iterate_generator → _GeneratorDone → Collector,
+    # producing an error dict rather than killing the flow.
+
+    def test_concurrent_streaming_error_asyncio_async_gen(self):
+        """Async generator raising mid-stream via asyncio mechanism.
+
+        Chunks emitted before the error should be collected, and the
+        Collector should emit an error dict for the failed stream.
+        """
+
+        async def error_stream(event):
+            yield f"{event}_chunk_0"
+            raise ValueError("async generator error mid-stream")
+
+        async def _run():
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    ConcurrentExecution(error_stream),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
+
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
+                result = await controller.await_termination()
+
+            assert len(result) == 1
+            assert isinstance(result[0], dict)
+            assert "error" in result[0]
+            assert "ValueError" in result[0]["error"]
+            assert "async generator error mid-stream" in result[0]["error"]
+
+        asyncio.run(_run())
+
+    @pytest.mark.parametrize(
+        "mechanism",
+        [
+            "thread_pool",
+            "process_pool",
+            "dedicated_process",
+            "naive",
+        ],
+    )
+    def test_concurrent_streaming_error_sync_gen(self, mechanism):
+        """Sync generator raising mid-stream across executor mechanisms.
+
+        Uses the module-level _sync_error_streaming_fn so it is picklable
+        for process-based mechanisms.
+        """
+
+        async def _run():
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    ConcurrentExecution(
+                        _sync_error_streaming_fn,
+                        concurrency_mechanism=mechanism,
+                    ),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
+
+            try:
+                await controller.emit("test")
+            finally:
+                await controller.terminate()
+                result = await controller.await_termination()
+
+            assert len(result) == 1
+            assert isinstance(result[0], dict)
+            assert "error" in result[0]
+            error_str = result[0]["error"]
+            assert "ValueError" in error_str
+            assert "sync generator error mid-stream" in error_str
+
+        asyncio.run(_run())
+
+    def test_concurrent_streaming_error_mixed_with_healthy(self):
+        """One event's generator fails while others succeed.
+
+        With max_in_flight > 1, a single failing generator must not
+        prevent healthy events from completing successfully.
+        """
+
+        async def maybe_error_stream(event):
+            yield f"{event}_chunk_0"
+            await asyncio.sleep(0)
+            if event == "event_bad":
+                raise ValueError("bad event error")
+            yield f"{event}_chunk_1"
+
+        async def _run():
+            controller = build_flow(
+                [
+                    AsyncEmitSource(),
+                    ConcurrentExecution(maybe_error_stream, max_in_flight=4),
+                    Collector(),
+                    Reduce([], lambda acc, x: acc + [x]),
+                ]
+            ).run()
+
+            await controller.emit("event_ok_1")
+            await controller.emit("event_bad")
+            await controller.emit("event_ok_2")
+
+            await controller.terminate()
+            result = await controller.await_termination()
+
+            assert len(result) == 3
+
+            error_results = [r for r in result if isinstance(r, dict) and "error" in r]
+            assert len(error_results) == 1
+            assert "ValueError" in error_results[0]["error"]
+            assert "bad event error" in error_results[0]["error"]
+
+            ok_results = [r for r in result if isinstance(r, list)]
+            assert len(ok_results) == 2
+            ok_chunks = {tuple(r) for r in ok_results}
+            assert ok_chunks == {
+                ("event_ok_1_chunk_0", "event_ok_1_chunk_1"),
+                ("event_ok_2_chunk_0", "event_ok_2_chunk_1"),
+            }
+
+        asyncio.run(_run())
 
 
 class TestSyncGeneratorEventLoopBlocking:


### PR DESCRIPTION
[ML-12378](https://iguazio.atlassian.net/browse/ML-12378)

## Problem

When `ConcurrentExecution` processes streaming (generator) event processors with `max_in_flight > 1`, the generators are iterated serially in the FIFO worker coroutine. This blocks the worker from picking up other events until the current generator is fully consumed, negating the concurrency benefit of `max_in_flight`.

## Root cause

`_handle_completed` called `_emit_streaming_chunks` (inherited from `_StreamingStepMixin`), which iterates the generator inline — holding the worker for the entire duration of each generator. With 4 events and a 0.5s generator, total time is ~2.0s instead of ~0.5s.

## Solution

Offload generator iteration to background `asyncio.Task`s that feed an `asyncio.Queue`, freeing the FIFO worker to process other events concurrently.

**New internal types:**
- `_GeneratorDone(error)` — sentinel placed on the queue when the generator is exhausted (or errors).
- `_StreamingQueue(queue, task)` — wraps the queue and its background task for lifecycle management.

**New methods on `ConcurrentExecution`:**
- `_iterate_generator` — background task that consumes a generator (sync or async) into an `asyncio.Queue`. Sync generators use `run_in_executor` per `next()` call to avoid blocking the event loop.
- `_emit_streaming_from_queue` — mirrors `_emit_streaming_chunks` but reads from the queue, emitting `StreamChunk` events and a final `StreamCompletion` (with error if the generator raised).

**Process-based mechanisms** (`process_pool`, `dedicated_process`) use the existing IPC pattern: `_concurrent_streaming_run_in_subprocess` runs the generator in the subprocess and streams chunks via `multiprocessing.Queue`, which `_async_read_streaming_queue` consumes as an async generator on the parent side.

**Task lifecycle:** `_StreamingQueue` holds the `asyncio.Task` reference, and `_handle_completed` awaits it after draining the queue. This prevents GC of fire-and-forget tasks and surfaces unexpected errors.

## Additional changes

- **Migrated `ConcurrentExecution` to `ParallelExecutionMechanisms`**: replaces the old `_supported_concurrency_mechanisms` list with the shared enum. Legacy names (`"threading"`, `"multiprocessing"`) are mapped automatically for backward compatibility.
- **Detects generator functions early** via `inspect.isgeneratorfunction` in `__init__`, used to route process-based mechanisms to the IPC streaming path in `_process_event`.

## Tests

- **Concurrency tests** (`test_concurrent_streaming_asyncio_async_gen`, `test_concurrent_streaming_sync_gen` parametrized over `thread_pool`/`process_pool`/`dedicated_process`/`naive`): verify generators run concurrently across events.
- **Error tests** (`test_concurrent_streaming_error_asyncio_async_gen`, `test_concurrent_streaming_error_sync_gen` parametrized over all mechanisms, `test_concurrent_streaming_error_mixed_with_healthy`): verify mid-stream errors propagate correctly and don't poison healthy concurrent events.

[ML-12378]: https://iguazio.atlassian.net/browse/ML-12378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ