### PR TITLE
Fix `ParquetTarget` blocking the event loop during emit

### DIFF
--- a/storey/targets.py
+++ b/storey/targets.py
@@ -606,7 +606,7 @@ class ParquetTarget(_Batching, _Writer):
     def _event_to_batch_entry(self, event):
         return self._event_to_writer_entry(event)
 
-    async def _emit(self, batch, batch_key, batch_time, batch_events, last_event_time=None):
+    def _blocking_emit(self, batch, batch_key, batch_time, batch_events, last_event_time=None):
         df_columns = []
         if self._non_partition_columns:
             if self._index_cols:
@@ -659,6 +659,12 @@ class ParquetTarget(_Batching, _Writer):
             df.to_parquet(path=file, index=bool(self._index_cols), version="2.4", **kwargs)
             if not self._last_written_event or last_event_time > self._last_written_event:
                 self._last_written_event = last_event_time
+
+    async def _emit(self, batch, batch_key, batch_time, batch_events, last_event_time=None):
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, self._blocking_emit, batch, batch_key, batch_time, batch_events, last_event_time
+        )
 
     async def _terminate(self):
         if self._mlrun_callback:


### PR DESCRIPTION
[ML-12406](https://iguazio.atlassian.net/browse/ML-12406)

`ParquetTarget._emit()` performs synchronous blocking I/O (fsspec filesystem operations and `df.to_parquet()`) directly inside the async event loop. This blocks all other async tasks from running for the duration of the write, which can be significant for large batches or slow storage backends.

The fix extracts the body of `_emit` into a synchronous `_blocking_emit` method and calls it via `asyncio.run_in_executor()`, offloading all DataFrame construction, filesystem access, and parquet serialization to a thread pool. This keeps the event loop responsive during writes.

[ML-12406]: https://iguazio.atlassian.net/browse/ML-12406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ