### PR TITLE
ML-12776: Route failing recovery steps to the error stream instead of poisoning the source

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -341,7 +341,7 @@ class Flow:
             event.error = ex
             try:
                 return await recovery_step._do(event)
-            except BaseException as recovery_ex:
+            except Exception as recovery_ex:
                 if getattr(recovery_ex, "_raised_by_storey_step", None) is None:
                     recovery_ex._raised_by_storey_step = recovery_step
                 return await self._handle_unrecovered_error(event, recovery_ex)
@@ -1220,11 +1220,22 @@ class _ConcurrentJobExecution(Flow):
                     ex._raised_by_storey_step = self
                     recovery_step = self._get_recovery_step(ex)
                     try:
+                        recovered = False
                         if recovery_step is not None:
                             event.origin_state = self.name
                             event.error = ex
-                            await recovery_step._do(event)
-                        else:
+                            try:
+                                await recovery_step._do(event)
+                                recovered = True
+                            except Exception as recovery_ex:
+                                # The recovery step (error handler) itself failed. Fall through to the
+                                # error-stream/raise handling below rather than propagating raw, which
+                                # would poison an explicit-ack source. recovery_step._do (not
+                                # _do_and_recover) is used to avoid infinite recovery loops.
+                                if getattr(recovery_ex, "_raised_by_storey_step", None) is None:
+                                    recovery_ex._raised_by_storey_step = recovery_step
+                                ex = recovery_ex
+                        if not recovered:
                             if event._awaitable_result:
                                 none_or_coroutine = event._awaitable_result._set_error(ex)
                                 if none_or_coroutine:

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1221,6 +1221,7 @@ class _ConcurrentJobExecution(Flow):
                     recovery_step = self._get_recovery_step(ex)
                     try:
                         recovered = False
+                        recovery_message = None
                         if recovery_step is not None:
                             event.origin_state = self.name
                             event.error = ex
@@ -1235,13 +1236,17 @@ class _ConcurrentJobExecution(Flow):
                                 if getattr(recovery_ex, "_raised_by_storey_step", None) is None:
                                     recovery_ex._raised_by_storey_step = recovery_step
                                 ex = recovery_ex
+                                # Capture while recovery_ex is still the active exception; once this
+                                # except block exits, sys.exc_info() reverts to the outer ex, so a
+                                # later traceback.format_exc() would format the wrong traceback.
+                                recovery_message = traceback.format_exc()
                         if not recovered:
                             if event._awaitable_result:
                                 none_or_coroutine = event._awaitable_result._set_error(ex)
                                 if none_or_coroutine:
                                     await none_or_coroutine
                             if self.context and hasattr(self.context, "push_error"):
-                                message = traceback.format_exc()
+                                message = recovery_message if recovery_message is not None else traceback.format_exc()
                                 if self.logger:
                                     self.logger.error(f"Pushing error to error stream: {ex}\n{message}")
                                 self.context.push_error(event, f"{ex}\n{message}", source=self.name)

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -336,21 +336,28 @@ class Flow:
             ex._raised_by_storey_step = self
             recovery_step = self._get_recovery_step(ex)
             if recovery_step is None:
-                if self.context and hasattr(self.context, "push_error"):
-                    message = traceback.format_exc()
-                    if event._awaitable_result:
-                        none_or_coroutine = event._awaitable_result._set_error(ex)
-                        if none_or_coroutine:
-                            await none_or_coroutine
-                    if self.logger:
-                        self.logger.error(f"Pushing error to error stream: {ex}\n{message}")
-                    self.context.push_error(event, f"{ex}\n{message}", source=self.name)
-                    return
-                else:
-                    raise ex
+                return await self._handle_unrecovered_error(event, ex)
             event.origin_state = self.name
             event.error = ex
-            return await recovery_step._do(event)
+            try:
+                return await recovery_step._do(event)
+            except BaseException as recovery_ex:
+                if getattr(recovery_ex, "_raised_by_storey_step", None) is None:
+                    recovery_ex._raised_by_storey_step = recovery_step
+                return await self._handle_unrecovered_error(event, recovery_ex)
+
+    async def _handle_unrecovered_error(self, event, ex):
+        if self.context and hasattr(self.context, "push_error"):
+            message = traceback.format_exc()
+            if event._awaitable_result:
+                none_or_coroutine = event._awaitable_result._set_error(ex)
+                if none_or_coroutine:
+                    await none_or_coroutine
+            if self.logger:
+                self.logger.error(f"Pushing error to error stream: {ex}\n{message}")
+            self.context.push_error(event, f"{ex}\n{message}", source=self.name)
+            return
+        raise ex
 
     @staticmethod
     def _event_string(event):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -628,6 +628,63 @@ def test_async_offset_commit_error_on_termination():
     asyncio.run(async_offset_commit_error_on_termination())
 
 
+async def async_offset_commit_with_failing_step(with_failing_recovery_step):
+    # Scenario: explicit-ack stream + a step that always raises. In one variant the step also has a
+    # recovery step (error handler) that ALSO always raises. Emit 5 events on a single shard. Even
+    # though every event fails, each one should still be committed so the stream keeps advancing and
+    # the source is not permanently poisoned (currently only the first failing event is committed,
+    # then the flow is stuck). The outcome is the same with or without the failing recovery step.
+    platform = Committer()
+    logger = MockLogger()
+    context = CommitterContext(platform, logger=logger)
+
+    # Model the nuclio/mlrun context, which always provides an error stream. Failed events should
+    # be routed here (dead-lettered) and then committed, rather than poisoning the source.
+    errors = []
+    context.push_error = lambda event, message, source=None: errors.append(event.offset)
+
+    def always_raise(_):
+        raise ATestException("step failed")
+
+    def recovery_always_raises(event):
+        # event.error holds the original exception that triggered recovery
+        raise RuntimeError(f"error handler failed (orig={type(event.error).__name__})")
+
+    # In mlrun every step carries the context (and thus the error stream), so pass it down here too.
+    steps = [AsyncEmitSource(context=context, explicit_ack=True, max_wait_before_commit=1)]
+    if with_failing_recovery_step:
+        error_handler = Map(recovery_always_raises, full_event=True, context=context)
+        steps.append(Map(always_raise, recovery_step=error_handler, context=context))
+        steps.append(error_handler)
+    else:
+        steps.append(Map(always_raise, context=context))
+    controller = build_flow(steps).run()
+
+    for offset in range(1, 6):
+        event = Event(offset)
+        event.shard_id = 0
+        event.offset = offset
+        await controller.emit(event)
+    del event
+
+    await asyncio.sleep(2)
+
+    try:
+        await controller.terminate(wait=True)
+    except Exception:
+        pass  # flow is poisoned today; the contract we're asserting is about offsets
+
+    # All 5 events failed, but each should be routed to the error stream and committed so the
+    # stream keeps advancing (the source is no longer poisoned).
+    assert platform.offsets == {("/", 0): 5}
+    assert errors == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.parametrize("with_failing_recovery_step", [False, True])
+def test_async_offset_commit_with_failing_step(with_failing_recovery_step):
+    asyncio.run(async_offset_commit_with_failing_step(with_failing_recovery_step))
+
+
 def test_multiple_upstreams():
     source = SyncEmitSource()
     map1 = Map(lambda x: x + 1)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4909,10 +4909,12 @@ def test_concurrent_execution_failing_recovery_step():
             await self._do_downstream(event)
 
     errors = []
+    messages = []
 
     class ContextWithPushError(Context):
         def push_error(self, event, message, source):
             errors.append(event.body)
+            messages.append(message)
 
     context = ContextWithPushError()
 
@@ -4929,6 +4931,9 @@ def test_concurrent_execution_failing_recovery_step():
     controller.await_termination()  # not poisoned: terminates cleanly
 
     assert sorted(errors) == [0, 1, 2, 3, 4]
+    # The dead-letter payload's traceback must be the recovery step's failure (captured while
+    # recovery_ex was the active exception), not the original step's traceback.
+    assert all("RuntimeError: error handler failed" in message for message in messages)
 
 
 def test_event_to_string():

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -669,13 +669,11 @@ async def async_offset_commit_with_failing_step(with_failing_recovery_step):
 
     await asyncio.sleep(2)
 
-    try:
-        await controller.terminate(wait=True)
-    except Exception:
-        pass  # flow is poisoned today; the contract we're asserting is about offsets
+    # The source is no longer poisoned by the failing (recovery) step, so termination is clean.
+    await controller.terminate(wait=True)
 
     # All 5 events failed, but each should be routed to the error stream and committed so the
-    # stream keeps advancing (the source is no longer poisoned).
+    # stream keeps advancing.
     assert platform.offsets == {("/", 0): 5}
     assert errors == [1, 2, 3, 4, 5]
 
@@ -4898,6 +4896,39 @@ def test_concurrent_execution_max_in_flight_push_error():
         awaitable_result.await_result()
     controller.terminate()
     controller.await_termination()
+
+
+# ML-12776: a concurrent step whose recovery step (error handler) also always raises must
+# dead-letter the event to the error stream instead of propagating raw and poisoning the flow.
+def test_concurrent_execution_failing_recovery_step():
+    class _RaisingConcurrentExecution(_ConcurrentJobExecution):
+        async def _process_event(self, event):
+            raise ATestException("step failed")
+
+        async def _handle_completed(self, event, response):
+            await self._do_downstream(event)
+
+    errors = []
+
+    class ContextWithPushError(Context):
+        def push_error(self, event, message, source):
+            errors.append(event.body)
+
+    context = ContextWithPushError()
+
+    def recovery_always_raises(event):
+        raise RuntimeError("error handler failed")
+
+    error_handler = Map(recovery_always_raises, full_event=True, context=context)
+    concurrent_step = _RaisingConcurrentExecution(max_in_flight=2, context=context, recovery_step=error_handler)
+    controller = build_flow([SyncEmitSource(context=context), concurrent_step, error_handler]).run()
+
+    for i in range(5):
+        controller.emit(i)
+    controller.terminate()
+    controller.await_termination()  # not poisoned: terminates cleanly
+
+    assert sorted(errors) == [0, 1, 2, 3, 4]
 
 
 def test_event_to_string():


### PR DESCRIPTION
## What

When a step has a recovery step (error handler) and that error handler **itself raises**, `Flow._do_and_recover` invoked the recovery step via `recovery_step._do(event)` and let the exception propagate raw. On an explicit-ack source this latched `self._ex`, **permanently poisoning the flow**: only the failing event's offset was committed, and every subsequent event was rejected at the emit gate and never processed or committed (the stream stalls).

## Fix

Wrap the recovery-step call so a failing error handler is routed through the same error-stream-or-raise handling as any other unrecovered error, extracted into a shared `_handle_unrecovered_error` helper (no duplication).

The recovery step is still invoked via `_do` (not `_do_and_recover`) and its failure is handled inline rather than re-entering recovery — so a recovery cycle (e.g. a graph-wide handler that is its own recovery step) **cannot loop infinitely**.

Note: failed events are committed only when the context exposes `push_error` (the mlrun/nuclio setup).

## Tests

Added `tests/test_flow.py::test_async_offset_commit_with_failing_step`, parametrized over a plain failing step and a failing recovery step, asserting all events are dead-lettered and committed.

## Jira

ML-12776 (fix version 1.12.0)