### PR TITLE
Tighten `is_batched_event` sub-event check

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -111,7 +111,7 @@ def is_batched_event(event) -> bool:
         not isinstance(event, StreamCompletion)
         and isinstance(getattr(event, "body", None), list)
         and event.body
-        and any(hasattr(sub_event, "body") for sub_event in event.body)
+        and any(hasattr(sub_event, "body") and "event" in type(sub_event).__name__.lower() for sub_event in event.body)
     )
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -81,6 +81,7 @@ from storey.flow import (
     RunnableExecutor,
     _Batching,
     _ConcurrentJobExecution,
+    is_batched_event,
 )
 from tests.helpers import MockContext, MockLogger
 
@@ -100,6 +101,20 @@ class RaiseEx:
         if self._counter == self._raise_after:
             raise ATestException("test")
         return element
+
+
+def test_is_batched_event_with_event_sub_events():
+    batched = Event(body=[Event(body=1), Event(body=2)])
+    assert is_batched_event(batched) is True
+
+
+def test_is_batched_event_excludes_non_event_body_objects():
+    class Response:
+        def __init__(self, body):
+            self.body = body
+
+    batched = Event(body=[Response(body=1), Response(body=2)])
+    assert is_batched_event(batched) is False
 
 
 def test_functional_flow():


### PR DESCRIPTION
## Summary

- `is_batched_event` previously classified any event whose body contained items with a `.body` attribute as batched. This caught non-event objects like mlrun's `Response`, which also exposes `.body`.
- Tightened the sub-event check to also require `"event"` in the class name (lowercased), preserving duck-typing for non-storey event-like objects while excluding `Response`-shaped payloads.
- Added unit tests covering the positive case (storey `Event` sub-events) and the negative case (`Response`-shaped sub-events).

## Test plan

- [x] `tests/test_flow.py::test_is_batched_event_with_event_sub_events`
- [x] `tests/test_flow.py::test_is_batched_event_excludes_non_event_body_objects`
- [ ] Existing batched-event flows still classify correctly in CI

Part of [ML-12706](https://ecliptos.atlassian.net/browse/ML-12706) effort.
