### PR TITLE
Make `v3io_frames` an optional dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,3 +17,4 @@ s3fs~=2023.9.2
 adlfs~=2023.9.0
 # If installing on MAC, you need to install PostgreSQL first using 'brew install postgresql'
 psycopg[binary,pool]~=3.2
+v3io-frames>=0.10.14, !=0.11.*, !=0.12.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pandas>=1, !=1.5.*, <2.2
 numpy>=1.16.5,<1.27
 # <24 is just a safeguard - no tests performed with pyarrow higher than 23
 pyarrow>=1,<24
-v3io-frames>=0.10.14, !=0.11.*, !=0.12.*
 fsspec>=0.6.2
 v3iofs~=0.1.17
 xxhash>=1

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ extras_require = {
         "opentelemetry-sdk>=1.25.0,<2.0.0",
         "opentelemetry-exporter-otlp-proto-grpc>=1.25.0,<2.0.0",
     ],
+    "v3io-frames": ["v3io-frames>=0.10.14, !=0.11.*, !=0.12.*"],
 }
 
 

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -28,8 +28,12 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import pyarrow
-import v3io_frames as frames
 import xxhash
+
+try:
+    import v3io_frames as frames
+except ImportError:
+    frames = None
 
 from . import Driver
 from .dtypes import Event, V3ioError
@@ -758,7 +762,11 @@ class TSDBTarget(_Batching, _Writer):
         self._aggr = aggr
         self.aggr_granularity = aggr_granularity
         self._created = False
-        self._frames_client = frames_client or frames.Client(address=v3io_frames, token=access_key, container=container)
+        if frames_client is None:
+            if frames is None:
+                raise ImportError("Install with: pip install storey[v3io-frames]")
+            frames_client = frames.Client(address=v3io_frames, token=access_key, container=container)
+        self._frames_client = frames_client
 
     def _init(self):
         _Batching._init(self)

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -762,6 +762,7 @@ class TSDBTarget(_Batching, _Writer):
         self._aggr = aggr
         self.aggr_granularity = aggr_granularity
         self._created = False
+        self._if_exists = frames.frames_pb2.IGNORE if frames is not None else 1  # frames_pb2.IGNORE
         if frames_client is None:
             if frames is None:
                 raise ImportError("Install with: pip install storey[v3io-frames]")
@@ -788,7 +789,7 @@ class TSDBTarget(_Batching, _Writer):
             self._frames_client.create(
                 "tsdb",
                 table=self._path,
-                if_exists=frames.frames_pb2.IGNORE,
+                if_exists=self._if_exists,
                 rate=self._rate,
                 aggregates=self._aggr,
                 aggregation_granularity=self.aggr_granularity or "",


### PR DESCRIPTION
ML-12819

**Motivation**
* V3IO is only supported in IG3
* airun-api needs to install and import mlrun, and we would like to make it run on Alpine instead of Debian, to help resolve ML-12814. v3io_frames pulls in protobuf, which gets in the way of that.

