### PR TITLE
Restore TLS certificate validation for `SendToHttp`

### DIFF
--- a/storey/flow.py
+++ b/storey/flow.py
@@ -1528,6 +1528,9 @@ class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
 class SendToHttp(_ConcurrentJobExecution):
     """Joins each event with data from any HTTP source. Used for event augmentation.
 
+    HTTPS certificates and hostnames are validated using aiohttp's default trust configuration. Deployments using
+    self-signed certificates or private certificate authorities must add their CA to the runtime trust configuration.
+
     :param request_builder: Creates an HTTP request from the event. This request is then sent to its destination.
     :type request_builder: Function (Event=>HttpRequest)
     :param join_from_response: Joins the original event with the HTTP response into a new event.
@@ -1557,7 +1560,7 @@ class SendToHttp(_ConcurrentJobExecution):
 
     async def _process_event(self, event):
         req = self._request_builder(event)
-        return await self._client_session.request(req.method, req.url, headers=req.headers, data=req.body, ssl=False)
+        return await self._client_session.request(req.method, req.url, headers=req.headers, data=req.body)
 
     async def _handle_completed(self, event, response):
         response_body = await response.text()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -24,7 +24,7 @@ import traceback
 import uuid
 from datetime import datetime
 from random import choice
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import fakeredis
 import pandas as pd
@@ -1969,6 +1969,27 @@ def test_awaitable_result_error_in_async_downstream():
             controller.emit(1).await_result()
     finally:
         controller.terminate()
+
+
+async def async_test_send_to_http_uses_default_tls_validation():
+    request = HttpRequest("POST", "https://example.com/resource", "request body", {"X-Test": "value"})
+    step = SendToHttp(lambda _: request, lambda event, response: event)
+    step._client_session = MagicMock()
+    step._client_session.request = AsyncMock()
+
+    await step._process_event(Event("event body"))
+
+    step._client_session.request.assert_awaited_once_with(
+        "POST",
+        "https://example.com/resource",
+        headers={"X-Test": "value"},
+        data="request body",
+    )
+    assert "ssl" not in step._client_session.request.await_args.kwargs
+
+
+def test_send_to_http_uses_default_tls_validation():
+    asyncio.run(async_test_send_to_http_uses_default_tls_validation())
 
 
 async def async_test_async_awaitable_result_error_in_async_downstream():


### PR DESCRIPTION
ML-13022

## Summary

- Remove the unconditional `ssl=False` override from `SendToHttp` so aiohttp validates HTTPS certificates and hostnames by default.
- Document that self-signed and private-CA deployments must configure the runtime trust store.
- Add a network-free regression test that verifies request data is forwarded without an SSL bypass.

## Compatibility

HTTPS endpoints whose certificates are not trusted by the Python runtime will now fail validation. This is an intentional security behavior change; affected deployments must add their CA to the runtime trust configuration.