### PR TITLE
Update vulnerable development dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,13 +3,13 @@ black>=26.3.1,<27
 flake8~=5.0
 flake8-bugbear~=22.9
 isort~=5.7
-pytest~=6.2.5
+pytest>=9.0.3,<10
 coverage~=7.5
-pytest-benchmark~=3.2.3
+pytest-benchmark>=5.2.3,<6
 # Note: you might need a Lua installation to install lupa on Mac.
 # brew install lua
-lupa~=1.13
-fakeredis~=1.9
+lupa>=2.8,<3
+fakeredis[lua]>=2.37,<3
 redis~=4.3
 # in sqlalchemy>=2.0 there is breaking changes (such as in Table class autoload argument is removed)
 sqlalchemy~=1.4

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -68,7 +68,7 @@ def setup_kv_teardown_test(request):
     elif test_context.driver_name == "RedisDriver":
         create_temp_redis_kv(test_context)
     elif test_context.driver_name == "SQLDriver":
-        pytest.skip(msg="test not relevant for SQLDriver")
+        pytest.skip("test not relevant for SQLDriver")
     else:
         raise ValueError(f'Unsupported driver name "{test_context.driver_name}"')
 

--- a/integration/test_flow_integration.py
+++ b/integration/test_flow_integration.py
@@ -186,7 +186,7 @@ def _get_table(setup_teardown_test, schema, keys, time_fields=None):
 
 def test_join_with_v3io_table(setup_kv_teardown_test):
     if setup_kv_teardown_test.driver_name == "RedisDriver":
-        pytest.skip(msg="test not relevant for Redis")
+        pytest.skip("test not relevant for Redis")
 
     table_path = setup_kv_teardown_test.table_name
     controller = build_flow(


### PR DESCRIPTION
ML-13022

- Upgrade pytest to the patched 9.x release range.
- Update pytest-benchmark for pytest 9 compatibility.
- Upgrade fakeredis and Lupa while preserving Lua-backed Redis test support.