### PR TITLE
Reduce remaining CodeQL quality findings

### DIFF
--- a/integration/test_flow_integration.py
+++ b/integration/test_flow_integration.py
@@ -524,11 +524,16 @@ def test_write_to_v3io_stream_unbalanced(assign_stream_teardown_test, sharding_f
     else:
         raise ValueError(f"Bad sharding_func_type: {sharding_func_type}")
 
+    if sharding_func_type == "field":
+        map_fn = lambda x: {"n": x}  # noqa: E731
+    else:
+        map_fn = str
+
     stream_path = assign_stream_teardown_test
     controller = build_flow(
         [
             SyncEmitSource(),
-            Map((lambda x: {"n": x}) if sharding_func_type == "field" else (lambda x: str(x))),
+            Map(map_fn),
             StreamTarget(
                 V3ioDriver(),
                 stream_path,

--- a/storey/aggregations.py
+++ b/storey/aggregations.py
@@ -238,6 +238,7 @@ class AggregateByKey(Flow):
                         await self._emit_event(key, event_from_batch["event"])
         except Exception as ex:
             raise ex
+        return None
 
     async def _sleep_and_emit(self):
         while self._events_in_batch:
@@ -388,8 +389,9 @@ class QueryByKey(AggregateByKey):
             if key is None or key == [None] or element is None:
                 event.body = None
                 await self._do_downstream(event)
-                return
+                return None
         await self._emit_event(key, event)
+        return None
 
     def _check_unique_names(self, aggregates):
         pass

--- a/storey/dataframe.py
+++ b/storey/dataframe.py
@@ -85,6 +85,7 @@ class ReduceToDataFrame(Flow):
                     self._id_column.append(event.id)
             else:
                 raise ValueError(f"ToDataFrame step only supports input of type dictionary or list, not {type(body)}")
+        return None
 
 
 class ToDataFrame(Flow):

--- a/storey/dtypes.py
+++ b/storey/dtypes.py
@@ -423,6 +423,8 @@ class EmitEveryEvent(EmitPolicy):
 
 
 def _dict_to_emit_policy(policy_dict):
+    if not isinstance(policy_dict, dict):
+        raise TypeError("emit policy must be a dict")
     mode = policy_dict.pop("mode")
     if mode == EmitEveryEvent.name():
         policy = EmitEveryEvent()

--- a/storey/flow.py
+++ b/storey/flow.py
@@ -329,7 +329,7 @@ class Flow:
         try:
             self.check_and_update_iteration_number(event)
             return await self._do(event)
-        except BaseException as ex:
+        except Exception as ex:
             if getattr(ex, "_raised_by_storey_step", None) is not None:
                 raise ex
             ex._raised_by_storey_step = self
@@ -425,7 +425,7 @@ class Flow:
         outlets = self._outlets if outlets is None else outlets
 
         if not outlets:
-            return
+            return None
         if event is _termination_obj:
             if self.logger:
                 outlet_names = ", ".join([outlet.name for outlet in outlets])
@@ -472,6 +472,7 @@ class Flow:
             if self.verbose and self.logger:
                 self.logger.debug(f"{step_name} -> {outlets[i].name} | {event_string}")
             await task
+        return None
 
     def _get_event_or_body(self, event):
         if self._full_event:
@@ -646,12 +647,13 @@ class Recover(Flow):
         else:
             try:
                 await super()._do_downstream(event)
-            except BaseException as ex:
+            except Exception as ex:
                 typ = type(ex)
                 if typ in self._exception_to_downstream:
                     await self._exception_to_downstream[typ]._do(event)
                 else:
                     raise ex
+        return None
 
 
 class _StreamingStepMixin:
@@ -755,6 +757,7 @@ class _UnaryFunctionFlow(Flow):
         element = self._get_event_or_body(event)
         fn_result = await self._call(element, self._fn)
         await self._do_internal(event, fn_result)
+        return None
 
     def select_outlets(self, event_body) -> Optional[Collection[str]]:
         if self._outlets_selector:
@@ -920,6 +923,7 @@ class _FunctionWithStateFlow(Flow):
         else:
             fn_result = await self._call(event)
             await self._do_internal(event, fn_result)
+        return None
 
 
 class MapWithState(_FunctionWithStateFlow):
@@ -992,6 +996,7 @@ class MapClass(Flow, _StreamingStepMixin):
                 await self._do_downstream(mapped_event)
         else:
             self._filter = False  # clear the flag for future runs
+        return None
 
 
 class Rename(Flow):
@@ -1122,7 +1127,7 @@ class Reduce(Flow):
             return self._result
         # Skip StreamCompletion - Reduce only processes actual event bodies
         if isinstance(event, StreamCompletion):
-            return
+            return None
         if self._full_event:
             elem = event
         else:
@@ -1131,6 +1136,7 @@ class Reduce(Flow):
         if self._is_async:
             res = await res
         self._result = res
+        return None
 
 
 class HttpRequest:
@@ -1214,7 +1220,15 @@ class _ConcurrentJobExecution(Flow):
                     completed = await job[1]
                     await self._handle_completed(event, completed)
                     await self._q.get()
-                except BaseException as ex:
+                except asyncio.CancelledError as ex:
+                    if job is not None and not self._q.empty():
+                        await self._q.get()
+                    if event is not None and event._awaitable_result:
+                        none_or_coroutine = event._awaitable_result._set_error(ex)
+                        if none_or_coroutine:
+                            await none_or_coroutine
+                    raise
+                except Exception as ex:
                     await self._q.get()
                     ex._raised_by_storey_step = self
                     recovery_step = self._get_recovery_step(ex)
@@ -1330,6 +1344,7 @@ class _ConcurrentJobExecution(Flow):
                 await self._q.put((event, task))
                 if self._worker_awaitable.done():
                     await self._worker_awaitable
+        return None
 
 
 class ConcurrentExecution(_ConcurrentJobExecution, _StreamingStepMixin):
@@ -1691,6 +1706,7 @@ class _Batching(Flow):
 
         if self._do_downstream_per_event:
             await self._do_downstream(event)
+        return None
 
     async def _sleep_and_emit(self):
         try:

--- a/storey/sources.py
+++ b/storey/sources.py
@@ -247,6 +247,7 @@ class FlowController(FlowControllerBase):
         self._emit_fn(_termination_obj)
         if wait:
             return self._await_termination_fn()
+        return None
 
     def await_termination(self):
         """Awaits the termination of the flow. To be called after terminate. Returns the termination result of the
@@ -343,6 +344,19 @@ class SyncEmitSource(Flow):
                 )
             raise
 
+    @staticmethod
+    def _set_event_error(event, ex):
+        if event is not _termination_obj and event._awaitable_result:
+            event._awaitable_result._set_error(ex)
+
+    def _fail_queued_events(self, ex):
+        while True:
+            try:
+                event = self._q.get_nowait()
+            except queue.Empty:
+                return
+            self._set_event_error(event, ex)
+
     async def _run_loop(self):
         loop = asyncio.get_running_loop()
         self._termination_future = loop.create_future()
@@ -395,20 +409,22 @@ class SyncEmitSource(Flow):
                     # all downstream steps completed successfully.
                     await _commit_handled_events(self._outstanding_offsets, committer, self.logger, commit_all=True)
                     self._termination_future.set_result(termination_result)
-            except BaseException as ex:
+            except asyncio.CancelledError as ex:
+                self._set_event_error(event, ex)
+                self._ex = ex
+                self._fail_queued_events(ex)
+                self._termination_future.set_result(None)
+                break
+            except Exception as ex:
                 if self.logger:
                     message = "An error was raised"
                     raised_by = getattr(ex, "_raised_by_storey_step", None)
                     if raised_by:
                         message += f" by step {type(raised_by)}"
                     self.logger.error(f"{message}: {traceback.format_exc()}")
-                if event is not _termination_obj and event._awaitable_result:
-                    event._awaitable_result._set_error(ex)
+                self._set_event_error(event, ex)
                 self._ex = ex
-                if not self._q.empty():
-                    event = self._q.get()
-                    if event is not _termination_obj and event._awaitable_result:
-                        event._awaitable_result._set_error(ex)
+                self._fail_queued_events(ex)
                 self._termination_future.set_result(None)
                 break
             if event is _termination_obj:
@@ -424,8 +440,12 @@ class SyncEmitSource(Flow):
                     self.logger.error(f"Error trying to close {closeable}: {ex}")
 
     def _loop_thread_main(self):
-        asyncio.run(self._run_loop_and_log_unexpected_error())
-        self._termination_q.put(self._ex)
+        try:
+            asyncio.run(self._run_loop_and_log_unexpected_error())
+        except (KeyboardInterrupt, SystemExit) as ex:
+            self._ex = ex
+        finally:
+            self._termination_q.put(self._ex)
 
     def _raise_on_error(self, ex):
         if ex:
@@ -614,6 +634,7 @@ class AsyncFlowController(FlowControllerBase):
             if isinstance(result, BaseException):
                 raise result
             return result
+        return None
 
     async def terminate(self, wait=False):
         """
@@ -626,6 +647,7 @@ class AsyncFlowController(FlowControllerBase):
         await self._emit_fn(_termination_obj)
         if wait:
             return await self.await_termination()
+        return None
 
     async def await_termination(self):
         """
@@ -726,6 +748,18 @@ class AsyncEmitSource(Flow):
                 )
             raise
 
+    @staticmethod
+    async def _set_event_error(event, ex):
+        if event is not _termination_obj and event._awaitable_result:
+            awaitable = event._awaitable_result._set_error(ex)
+            if awaitable:
+                await awaitable
+
+    async def _fail_queued_events(self, ex):
+        while not self._q.empty():
+            event = await self._q.get()
+            await self._set_event_error(event, ex)
+
     async def _run_loop(self):
         committer = None
         num_offsets_not_handled = 0
@@ -774,7 +808,12 @@ class AsyncEmitSource(Flow):
                     # We can commit all at this point because termination of
                     # all downstream steps completed successfully.
                     return termination_result
-            except BaseException as ex:
+            except asyncio.CancelledError as ex:
+                self._ex = ex
+                await self._set_event_error(event, ex)
+                await self._fail_queued_events(ex)
+                raise
+            except Exception as ex:
                 if self.logger:
                     message = "An error was raised"
                     raised_by = getattr(ex, "_raised_by_storey_step", None)
@@ -782,12 +821,8 @@ class AsyncEmitSource(Flow):
                         message += f" by step {type(raised_by)}"
                     self.logger.error(f"{message}: {traceback.format_exc()}")
                 self._ex = ex
-                if event is not _termination_obj and event._awaitable_result:
-                    awaitable = event._awaitable_result._set_error(ex)
-                    if awaitable:
-                        await awaitable
-                if not self._q.empty():
-                    await self._q.get()
+                await self._set_event_error(event, ex)
+                await self._fail_queued_events(ex)
                 self._raise_on_error()
             finally:
                 if event is _termination_obj or self._ex:

--- a/storey/steps/assertion.py
+++ b/storey/steps/assertion.py
@@ -163,3 +163,4 @@ class Assert(Flow):
             assertion(element)
 
         await self._do_downstream(event)
+        return None

--- a/storey/steps/partition.py
+++ b/storey/steps/partition.py
@@ -45,3 +45,4 @@ class Partition(Flow):
             else:
                 event.body = Partitioned(left=None, right=event.body)
             await self._do_downstream(event)
+        return None

--- a/storey/steps/sample.py
+++ b/storey/steps/sample.py
@@ -113,6 +113,7 @@ class SampleWindow(Flow):
             if self._should_emit(count):
                 self._last_event = None
                 await self._do_downstream(event)
+        return None
 
     def _should_emit(self, count):
         if self._emit_period == EmitPeriod.FIRST and count == 1:

--- a/storey/table.py
+++ b/storey/table.py
@@ -388,9 +388,10 @@ class Table:
                         await self._persist(_PersistJob(key, None, None))
                         self._changed_keys.discard(key)
 
-        except BaseException as ex:
-            if not isinstance(ex, asyncio.CancelledError):
-                self._flush_exception = ex
+        except asyncio.CancelledError:
+            pass  # Expected when the flush task is cancelled during termination.
+        except Exception as ex:
+            self._flush_exception = ex
 
         self._pending_events = []
 

--- a/storey/targets.py
+++ b/storey/targets.py
@@ -981,7 +981,7 @@ class StreamTarget(Flow, _Writer):
                             await self._handle_response(req)
                             in_flight_events[shard_id] = None
                         self._send_batch(buffers, in_flight_reqs, buffer_events, in_flight_events, shard_id)
-                except BaseException as ex:
+                except Exception as ex:
                     ex._raised_by_storey_step = self
                     if self.context and hasattr(self.context, "push_error"):
                         message = traceback.format_exc()
@@ -1048,6 +1048,7 @@ class StreamTarget(Flow, _Writer):
             await self._q.put(event)
             if self._worker_exited:
                 await self._worker_awaitable
+        return None
 
 
 class KafkaTarget(Flow, _Writer):
@@ -1154,6 +1155,7 @@ class KafkaTarget(Flow, _Writer):
             future = self._producer.send(self._topic, record, key, partition=partition)
             # Prevent garbage collection of event until persisted to kafka
             future.add_callback(lambda x: event)
+        return None
 
 
 class NoSqlTarget(_Writer, Flow):
@@ -1229,3 +1231,4 @@ class NoSqlTarget(_Writer, Flow):
                 self._table._pending_events.append(event)
             self._table._init_flush_task()
             await self._do_downstream(event)
+        return None

--- a/storey/windowed_store.py
+++ b/storey/windowed_store.py
@@ -90,6 +90,7 @@ class Window(Flow):
         ):
             await self.emit_window()
             self._events_in_batch = 0
+        return None
 
     async def emit_window(self):
         store_to_emit = copy.deepcopy(self._windowed_store)

--- a/tests/test_concurrent_execution.py
+++ b/tests/test_concurrent_execution.py
@@ -104,6 +104,34 @@ def test_concurrent_execution_multiprocessing_and_complete():
     asyncio.run(async_test_concurrent_execution_multiprocessing_and_complete())
 
 
+async def async_test_concurrent_execution_cancellation_reaches_waiters():
+    async def cancel(_):
+        raise asyncio.CancelledError()
+
+    controller = build_flow(
+        [
+            AsyncEmitSource(),
+            ConcurrentExecution(
+                event_processor=cancel,
+                concurrency_mechanism="asyncio",
+                max_in_flight=2,
+            ),
+            Complete(),
+        ]
+    ).run()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(controller.emit("cancel"), timeout=1)
+
+    await controller.terminate()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(controller.await_termination(), timeout=1)
+
+
+def test_concurrent_execution_cancellation_reaches_waiters():
+    asyncio.run(async_test_concurrent_execution_cancellation_reaches_waiters())
+
+
 def test_concurrent_execution_multiprocessing_and_full_event():
     with pytest.raises(
         ValueError,

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -19,6 +19,7 @@ import multiprocessing.context
 import os
 import queue
 import tempfile
+import threading
 import time
 import traceback
 import uuid
@@ -35,7 +36,6 @@ from packaging import version
 from pandas.testing import assert_frame_equal
 
 import integration.conftest
-import storey
 from storey import (
     AsyncEmitSource,
     Batch,
@@ -49,6 +49,7 @@ from storey import (
     Extend,
     Filter,
     FlatMap,
+    Flow,
     HttpRequest,
     JoinWithTable,
     Map,
@@ -71,6 +72,7 @@ from storey import (
     V3ioDriver,
     build_flow,
 )
+from storey.dtypes import _termination_obj
 from storey.flow import (
     ConcurrentExecution,
     Context,
@@ -179,11 +181,11 @@ class CommitterContext:
         self.verbose = verbose
 
 
-class EventHoarder(storey.Flow):
+class EventHoarder(Flow):
     events = []
 
     async def _do(self, event):
-        if event is storey.dtypes._termination_obj:
+        if event is _termination_obj:
             self.events = []
             print("Hoarder terminated")
         else:
@@ -192,9 +194,9 @@ class EventHoarder(storey.Flow):
         return await self._do_downstream(event)
 
 
-class ErrorOnTermination(storey.Flow):
+class ErrorOnTermination(Flow):
     async def _do(self, event):
-        if event is storey.dtypes._termination_obj:
+        if event is _termination_obj:
             raise ATestException("We raise this error on termination on purpose")
         return await self._do_downstream(event)
 
@@ -755,13 +757,13 @@ def test_multiple_upstreams_completion():
 
 # ML-1167
 def test_multiple_upstreams_termination():
-    class FailOnSubsequentTermination(storey.Flow):
+    class FailOnSubsequentTermination(Flow):
         def _init(self):
             super()._init()
             self.terminated = False
 
         async def _do(self, event):
-            if event is storey.dtypes._termination_obj:
+            if event is _termination_obj:
                 if self.terminated:
                     raise AssertionError("Termination must only be received once")
                 self.terminated = True
@@ -1883,6 +1885,24 @@ def test_awaitable_result_error():
         controller.terminate()
 
 
+def test_awaitable_result_cancelled():
+    release = threading.Event()
+
+    def cancel(_):
+        release.wait()
+        raise asyncio.CancelledError()
+
+    controller = build_flow([SyncEmitSource(), Map(cancel), Complete()]).run()
+    awaitable_results = [controller.emit(i) for i in range(3)]
+    release.set()
+
+    for awaitable_result in awaitable_results:
+        with pytest.raises(asyncio.CancelledError):
+            awaitable_result.await_result()
+    with pytest.raises(asyncio.CancelledError):
+        controller.await_termination()
+
+
 async def async_test_async_awaitable_result_error():
     def boom(_):
         raise ValueError("boom")
@@ -1899,6 +1919,31 @@ async def async_test_async_awaitable_result_error():
 
 def test_async_awaitable_result_error():
     asyncio.run(async_test_async_awaitable_result_error())
+
+
+async def async_test_async_awaitable_result_cancelled():
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def cancel(_):
+        started.set()
+        await release.wait()
+        raise asyncio.CancelledError()
+
+    controller = build_flow([AsyncEmitSource(), Map(cancel), Complete()]).run()
+    emit_tasks = [asyncio.create_task(controller.emit(i)) for i in range(3)]
+    await started.wait()
+    await asyncio.sleep(0)
+    release.set()
+
+    results = await asyncio.wait_for(asyncio.gather(*emit_tasks, return_exceptions=True), timeout=1)
+    assert all(isinstance(result, asyncio.CancelledError) for result in results)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(controller.await_termination(), timeout=1)
+
+
+def test_async_awaitable_result_cancelled():
+    asyncio.run(async_test_async_awaitable_result_cancelled())
 
 
 def test_complete_without_awaitable_result():
@@ -4311,7 +4356,7 @@ def test_split_flow_to_code():
     flow = build_flow(
         [
             SyncEmitSource(),
-            [Batch(5), Reduce([], lambda x: len(x))],
+            [Batch(5), Reduce([], lambda _acc, x: len(x))],
             Batch(5),
             ToDataFrame(index=[]),
             Reduce([], append_and_return, full_event=True),
@@ -5008,7 +5053,7 @@ def test_verbose_logs():
 
 # ML-1716
 def test_init_of_recovery_step():
-    class WasInitCalled(storey.Flow):
+    class WasInitCalled(Flow):
         def __init__(self):
             super().__init__()
             self.times_init_called = 0
@@ -5036,7 +5081,7 @@ def test_init_of_recovery_step():
     [(True, True), (True, False), (False, True), (False, False)],
 )
 def test_long_running_parameter(long_running, use_mapclass):
-    class CheckTime(storey.Flow):
+    class CheckTime(Flow):
         def __init__(self):
             super().__init__()
             self.failed = False
@@ -5054,7 +5099,7 @@ def test_long_running_parameter(long_running, use_mapclass):
         async def _do(self, event):
             if not self._worker_task:
                 self._worker_task = asyncio.create_task(self.worker())
-            if event is storey.dtypes._termination_obj:
+            if event is _termination_obj:
                 self._terminate = True
                 await self._worker_task
             return await self._do_downstream(event)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -44,6 +44,11 @@ def test_emit_policy_wrong_type():
         _dict_to_emit_policy(policy_dict)
 
 
+def test_emit_policy_not_a_dict():
+    with pytest.raises(TypeError):
+        _dict_to_emit_policy(EmitEveryEvent.name())
+
+
 def test_emit_policy_wrong_args():
     policy_dict = {"mode": EmitAfterWindow.name(), "daily": 8}
     with pytest.raises(ValueError):


### PR DESCRIPTION
Follow up on #649.

## Summary

- Make flow, controller, and target return behavior explicit without changing runtime results.
- Narrow recovery and worker handlers to `Exception` so cancellation and process-control exceptions propagate correctly.
- Deliver failures to all queued and in-flight event waiters instead of leaving them blocked.
- Preserve expected table-flush cancellation handling while recording ordinary failures.
- Validate emit-policy input types and clean up the remaining test callbacks and imports.

## Findings left unchanged

Required asynchronous waits, explicit multiple-inheritance initialization, the exported termination sentinel, the iterable-source thread boundary, and the exhaustive integration driver factory remain unchanged because their reported patterns are intentional.